### PR TITLE
Fix/live greeting and complete status

### DIFF
--- a/apps/agent/src/deepinterview_agent/api/views.py
+++ b/apps/agent/src/deepinterview_agent/api/views.py
@@ -16,7 +16,10 @@ from ..shared_models import InterviewContext
 
 __all__ = ["SessionView", "SessionStatus", "PROGRESS_STEPS"]
 
-SessionStatus = Literal["prep", "ready", "rejected", "error"]
+# "complete" is the terminal state set by the post-interview scoring step
+# (see post/__init__.py); it must be a valid status or GET /api/session/{id}
+# 500s on any read after an interview ends, blocking re-joins.
+SessionStatus = Literal["prep", "ready", "rejected", "error", "complete"]
 
 # The canonical ordered set of prep steps a session progresses through. Reported
 # back as completed-step keys (a subset/permutation of these) in SessionView.

--- a/apps/agent/src/deepinterview_agent/live/interviewer.py
+++ b/apps/agent/src/deepinterview_agent/live/interviewer.py
@@ -60,6 +60,37 @@ class Interviewer(Agent):
     def __init__(self, userdata: InterviewUserdata) -> None:
         super().__init__(instructions=build_instructions(userdata))
 
+    async def on_enter(self) -> None:
+        """Open the interview proactively: greet the candidate and ask Q1.
+
+        LiveKit calls this when the agent becomes the active speaker. Without it
+        the agent stays silent until the candidate speaks first (the avatar sits
+        on its idle loop). We drive the first turn with ``generate_reply``
+        (synchronous in livekit-agents 1.x — returns a SpeechHandle) using the
+        lean context already in the system prompt; subsequent turns flow through
+        the tools. Persona handoffs subclass ``Agent`` directly, so this opener
+        fires once, only for the base interviewer.
+        """
+        ud = self.session.userdata
+        primary = ud.ctx.plan.language_mode.primary
+        q = state.current_question(ud)
+        question_line = (
+            _localized(q.text, primary) if q is not None else "(no further questions)"
+        )
+        if q is not None:
+            state.add_turn(ud, "assistant", question_line)
+        first_name = (ud.ctx.candidate.name or "there").split()[0]
+        self.session.generate_reply(
+            instructions=(
+                f"Open the interview now, speaking in {primary}. Warmly greet the "
+                f"candidate by first name ({first_name}) in one short sentence and "
+                f"say you'll be running their mock interview for the {ud.ctx.job.title} "
+                f"role at {ud.ctx.job.company_name}. Then ask this first question and "
+                f"stop: {question_line}. Keep it natural and concise; do not call any "
+                "tools yet."
+            )
+        )
+
     @function_tool
     async def save_answer(
         self,

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -11,7 +11,7 @@ import { InterviewContextSchema } from "@deepinterview/shared";
  */
 export const SessionViewSchema = z.object({
   session_id: z.string(),
-  status: z.enum(["prep", "ready", "rejected", "error"]),
+  status: z.enum(["prep", "ready", "rejected", "error", "complete"]),
   progress: z.array(z.string()),
   prep_warnings: z.array(z.string()),
   context: InterviewContextSchema.nullable(),


### PR DESCRIPTION
<!--
Thanks for contributing to DeepInterview! Keep PRs small — one work package
(or one focused change) per PR. See CONTRIBUTING.md for the full workflow.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences. -->

## Linked issue

<!-- e.g. "Closes #123" / "Part of #123". Use "Closes" to auto-close on merge. -->

Closes #

## Work package

<!-- Which WP does this touch? See AI-Interviewer-Build-Handoff.md §16. -->

- [ ] WP-0 — Monorepo + shared contracts + CLI scaffold
- [ ] WP-1 — Web: auth + setup/onboarding
- [ ] WP-2 — Web: live interview screen
- [ ] WP-3 — Web: report / feedback screen
- [ ] WP-4 — Web: Prep Coach UI
- [ ] WP-5 — Agent: live voice interviewer
- [ ] WP-6 — Agent: prep pipeline
- [ ] WP-7 — Agent: scoring pipeline
- [ ] WP-8 — Knowledge service (LightRAG)
- [ ] WP-9 — Avatar system
- [ ] WP-10 — Skill library + distiller
- [ ] WP-11 — Payments + plan gating
- [ ] WP-12 — DevOps / deploy / observability
- [ ] WP-13 — OSS launch assets
- [ ] Other / cross-cutting (docs, chore, CI)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
      (`feat:`, `fix:`, `docs:`, `chore:`, …).
- [ ] `pnpm build` is green.
- [ ] `pnpm typecheck` is green.
- [ ] `pnpm lint` is green.
- [ ] `pnpm test` is green.
- [ ] `uv --directory apps/agent run pytest` is green (if Python touched).
- [ ] The **offline / mock-first** path still works with **no API keys set**
      (no provider key required to run the prep → live → post loop locally).
- [ ] No secrets committed (`.env*`, real keys/tokens, recordings).
- [ ] Docs updated where behavior or contracts changed (README, `docs/`,
      `packages/shared` contract docs, or the handoff spec).
- [ ] Shared contracts stay in sync: TS ↔ Pydantic parity holds
      (`packages/shared` + the agent parity test) if I changed any contract.

## Screenshots / recordings

<!-- REQUIRED for any UI change. Before/after images or a short clip.
     Delete this section only if the PR has no user-facing UI. -->

## Notes for reviewers

<!-- Anything tricky, follow-ups, or out-of-scope items intentionally left. -->
