### PR TITLE
Merge resilience fixes into main (fail-soft scoring, cost guard, coverage_pct)

### DIFF
--- a/apps/agent/src/deepinterview_agent/core/config.py
+++ b/apps/agent/src/deepinterview_agent/core/config.py
@@ -62,6 +62,24 @@ class Settings(BaseSettings):
     agent_api_port: int = 8000
     default_language: str = "en"
 
+    # --- live cost / duration guard (Golden Rule #5: cap voice in code) -------
+    # Hard ceilings enforced by the worker's SessionGuard so a live room can
+    # never run unbounded (a stalled/looping LLM would otherwise burn voice
+    # minutes forever). These are the in-code per-tier caps; a per-session
+    # override can later be threaded in via RoomMetadata.
+    max_interview_duration_sec: int = 1200  # 20 min wall-clock hard stop
+    max_interview_turns: int = 80  # transcript turns hard stop
+
+    # --- post / scoring resilience -------------------------------------------
+    # Per-stage timeout for the (latency-tolerant) scoring pipeline; on timeout
+    # or error the stage degrades to a valid fallback instead of failing the
+    # whole scorecard. See post/__init__.py.
+    score_stage_timeout_sec: float = 60.0
+    # Closed-loop skill distiller (WP-10): when enabled, a scored interview
+    # proposes a playbook delta into the review queue. OFF by default so tests
+    # and local runs don't write drafts; enable in production via env.
+    enable_skill_distiller: bool = False
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/apps/agent/src/deepinterview_agent/live/guard.py
+++ b/apps/agent/src/deepinterview_agent/live/guard.py
@@ -1,0 +1,109 @@
+"""Hard cost / duration guard for the live interview (Golden Rule #5).
+
+REQUIRES the optional ``livekit-agents`` extra at runtime (it is started from
+the worker), but its only hard dependency is ``asyncio`` + the livekit-free
+``state`` module: it talks to the running session through a tiny duck-typed
+surface (``say`` / ``shutdown``), so it is fully unit-testable with a fake
+session and a fake clock.
+
+The :class:`SessionGuard` runs OFF the turn-critical path as a fire-and-forget
+asyncio task (like :class:`~deepinterview_agent.live.director.Director`). It
+enforces two ceilings — wall-clock duration and total transcript turns — and,
+when either is reached, says a brief closing line and shuts the session down
+gracefully (draining), which triggers the worker's persist + score shutdown
+callback. The web layer caps interview *creation* per tier; this is the in-room
+backstop so a stalled or looping model can never run a voice session unbounded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import TYPE_CHECKING, Callable
+
+from ..core.logging import get_logger
+
+if TYPE_CHECKING:
+    from .state import InterviewUserdata
+
+log = get_logger(__name__)
+
+_WRAP_UP_LINE = (
+    "We're at time for this interview, so let's wrap up here. "
+    "Thank you — your feedback will be ready shortly."
+)
+
+
+class SessionGuard:
+    """Enforce hard duration/turn ceilings on a live session; never blocks a turn.
+
+    ``session`` only needs an async ``say(text)`` and a ``shutdown(*, drain)``
+    method (the livekit ``AgentSession`` surface), so tests can pass a fake.
+    ``time_fn`` defaults to :func:`time.monotonic` and is injectable for tests.
+    """
+
+    def __init__(
+        self,
+        session: object,
+        userdata: InterviewUserdata,
+        *,
+        max_duration_sec: float,
+        max_turns: int,
+        interval_sec: float = 2.0,
+        time_fn: Callable[[], float] | None = None,
+    ) -> None:
+        self._session = session
+        self._ud = userdata
+        self._max_duration = float(max_duration_sec)
+        self._max_turns = int(max_turns)
+        self._interval = interval_sec
+        self._time = time_fn or time.monotonic
+        self._task: asyncio.Task[None] | None = None
+        self._started_at: float = 0.0
+        self.tripped: bool = False
+
+    def start(self) -> None:
+        """Launch the guard as a detached background task (idempotent)."""
+        if self._task is None:
+            self._started_at = self._time()
+            self._task = asyncio.create_task(self._run())
+
+    async def aclose(self) -> None:
+        """Stop the guard (idempotent)."""
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+    def _limit_reached(self, elapsed: float) -> str | None:
+        """Return a human reason if a ceiling is hit, else ``None``."""
+        if elapsed >= self._max_duration:
+            return f"max duration {self._max_duration:.0f}s reached"
+        turns = len(self._ud.transcript)
+        if turns >= self._max_turns:
+            return f"max turns {self._max_turns} reached"
+        return None
+
+    async def _wrap_up(self, reason: str) -> None:
+        """Say a closing line (best-effort) then shut the session down gracefully."""
+        log.warning("session_guard: %s for %s — wrapping up", reason, self._ud.session_id)
+        with contextlib.suppress(Exception):
+            await self._session.say(_WRAP_UP_LINE)  # type: ignore[attr-defined]
+        with contextlib.suppress(Exception):
+            self._session.shutdown(drain=True)  # type: ignore[attr-defined]
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                reason = self._limit_reached(self._time() - self._started_at)
+                if reason is not None:
+                    self.tripped = True
+                    await self._wrap_up(reason)
+                    return
+                await asyncio.sleep(self._interval)
+        except asyncio.CancelledError:  # pragma: no cover - cancellation path
+            raise
+        except Exception:  # noqa: BLE001 - a guard must never crash the call
+            log.exception("session_guard: watcher error (ignored)")

--- a/apps/agent/src/deepinterview_agent/post/__init__.py
+++ b/apps/agent/src/deepinterview_agent/post/__init__.py
@@ -22,16 +22,25 @@ subset) is what the Prep Coach consumes to choose what to teach next.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
+from ..core.logging import get_logger
 from ..shared_models import LanguageReport, ScoreCard
 from .evaluator import evaluate
 from .language_coach import coach
-from .report import generate_report
+from .report import (
+    _coverage_pct,
+    _overall_score,
+    _weak_competencies,
+    generate_report,
+)
 
 if TYPE_CHECKING:
     from ..core.deps import Deps
-    from ..shared_models import ScoreRequest
+    from ..shared_models import CompetencyScore, InterviewContext, ScoreRequest
+
+log = get_logger(__name__)
 
 __all__ = ["run_score", "evaluate", "coach", "generate_report"]
 
@@ -55,11 +64,92 @@ def _missing_context_scorecard(session_id: str) -> ScoreCard:
             summary="No interview context was found for this session.",
         ),
         summary=f"No interview context was found for session {session_id}; nothing to score.",
+        coverage_pct=0.0,
     )
 
 
+def _fallback_language_report() -> LanguageReport:
+    """Neutral, well-formed language report used when the coach stage fails."""
+    return LanguageReport(
+        fluency_score=0.0,
+        filler_word_count=0,
+        clarity_score=0.0,
+        code_switching_notes="",
+        pronunciation_notes="",
+        summary="Spoken-language assessment was unavailable for this interview.",
+    )
+
+
+def _degraded_scorecard(
+    ctx: InterviewContext,
+    comp_scores: list[CompetencyScore],
+    lang_report: LanguageReport,
+) -> ScoreCard:
+    """A valid ScoreCard assembled WITHOUT the LLM narrative.
+
+    Used when report generation (the narrative + model-answer LLM calls) fails
+    but competency scoring and/or the language report succeeded. Preserves the
+    numbers already computed so a transient model error never discards a
+    completed interview's work.
+    """
+    return ScoreCard(
+        overall_score=_overall_score(comp_scores),
+        competency_scores=comp_scores,
+        strengths=[],
+        weaknesses=[],
+        weak_competencies=_weak_competencies(comp_scores),
+        model_answers=[],
+        next_steps=["Re-run scoring to generate the full written report."],
+        language_report=lang_report,
+        summary=(
+            "Partial scorecard: detailed report generation was temporarily "
+            "unavailable. Competency scores are preserved; re-run scoring for "
+            "the full narrative and model answers."
+        ),
+        coverage_pct=_coverage_pct(ctx),
+    )
+
+
+async def _guarded(coro, *, label: str, timeout: float):
+    """Await ``coro`` with a timeout; on ANY error return ``None`` to fall back.
+
+    The scoring pipeline is latency-tolerant but must never let one transient
+    provider error or hang destroy a completed interview's scorecard.
+    """
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout)
+    except Exception:  # noqa: BLE001 - degrade, never propagate, on the scoring path
+        log.exception("post: scoring stage %r failed; degrading", label)
+        return None
+
+
+async def _maybe_distill_skill(session_id: str, deps: Deps) -> None:
+    """Best-effort closed-loop step (WP-10): propose a reusable playbook delta.
+
+    Gated behind ``settings.enable_skill_distiller`` (OFF by default). Writes a
+    draft into the review queue only — never the live library, never the score
+    response. Any failure is logged and swallowed.
+    """
+    if not deps.settings.enable_skill_distiller:
+        return
+    try:
+        from ..skilllib.distiller import propose_skill  # noqa: PLC0415 - keep skilllib off the import hot path
+
+        draft = await propose_skill(session_id, deps)
+        log.info("post: skill distiller proposed draft %s for session %s", draft.id, session_id)
+    except Exception:  # noqa: BLE001 - distiller is best-effort; must not affect scoring
+        log.exception("post: skill distiller failed for session %s", session_id)
+
+
 async def run_score(req: ScoreRequest, deps: Deps) -> ScoreCard:
-    """Score an interview session and return (and persist) its ``ScoreCard``."""
+    """Score an interview session and return (and persist) its ``ScoreCard``.
+
+    Each stage (evaluate / coach / report) is individually guarded with a
+    timeout and a structured fallback, so a transient provider failure degrades
+    the scorecard rather than raising (which would 500 the API and leave the
+    session stuck mid-scoring). Whenever a context exists the resulting card is
+    persisted and the session is marked ``complete``.
+    """
     ctx = await deps.repo.load_context(req.session_id)
     if ctx is None:
         # No context to score. Returning (rather than persisting) is correct for
@@ -67,10 +157,29 @@ async def run_score(req: ScoreRequest, deps: Deps) -> ScoreCard:
         # (don't overwrite its "error" status with "complete").
         return _missing_context_scorecard(req.session_id)
 
-    comp_scores = await evaluate(ctx, deps)
-    lang_report = await coach(ctx, deps)
-    scorecard = await generate_report(ctx, comp_scores, lang_report, deps)
+    timeout = deps.settings.score_stage_timeout_sec
+
+    comp_scores = await _guarded(evaluate(ctx, deps), label="evaluate", timeout=timeout)
+    if comp_scores is None:
+        comp_scores = []
+
+    lang_report = await _guarded(coach(ctx, deps), label="coach", timeout=timeout)
+    if lang_report is None:
+        lang_report = _fallback_language_report()
+
+    scorecard = await _guarded(
+        generate_report(ctx, comp_scores, lang_report, deps),
+        label="generate_report",
+        timeout=timeout,
+    )
+    if scorecard is None:
+        scorecard = _degraded_scorecard(ctx, comp_scores, lang_report)
 
     await deps.repo.save_scorecard(req.session_id, scorecard)
     await deps.repo.update_status(req.session_id, "complete")
+
+    # Closed-loop (WP-10): propose a reusable playbook delta. Off by default,
+    # best-effort, and fully guarded so it can never affect the returned card.
+    await _maybe_distill_skill(req.session_id, deps)
+
     return scorecard

--- a/apps/agent/src/deepinterview_agent/post/evaluator.py
+++ b/apps/agent/src/deepinterview_agent/post/evaluator.py
@@ -108,12 +108,17 @@ async def evaluate(ctx: InterviewContext, deps: Deps) -> list[CompetencyScore]:
 
     Each ``CompetencyScore.competency`` equals the corresponding question's
     ``target_competency`` — the mapping the report and the Prep Coach loop rely
-    on. Questions without a matching answer are scored low with non-evidence
-    text rather than dropped.
+    on. Questions that were never answered (no record, or an empty transcript)
+    are SKIPPED rather than scored ``0.0``: a competency we never probed must
+    not read as a weak one (that would poison ``overall_score`` and tell the
+    Prep Coach to teach something the interview simply didn't reach). The
+    fraction actually covered is reported separately as ``ScoreCard.coverage_pct``.
     """
     by_question = _answers_by_question(ctx)
     raw_scores: list[CompetencyScore] = []
     for question in ctx.plan.questions:
         answer = by_question.get(question.id)
+        if answer is None or not (answer.transcript and answer.transcript.strip()):
+            continue  # unanswered: not assessable — see ScoreCard.coverage_pct
         raw_scores.append(await _score_question(question, answer, deps))
     return _merge_by_competency(raw_scores)

--- a/apps/agent/src/deepinterview_agent/post/report.py
+++ b/apps/agent/src/deepinterview_agent/post/report.py
@@ -57,6 +57,21 @@ def _weak_competencies(comp_scores: list[CompetencyScore]) -> list[str]:
     return weak
 
 
+def _coverage_pct(ctx: InterviewContext) -> float:
+    """Fraction of planned questions that received a non-empty answer.
+
+    1.0 when nothing was planned (vacuously complete). This is the signal that
+    tells a low ``overall_score`` from a short/aborted interview apart from one
+    earned by genuinely weak answers.
+    """
+    total = len(ctx.plan.questions)
+    if total == 0:
+        return 1.0
+    answered_ids = {a.question_id for a in ctx.answers if a.transcript and a.transcript.strip()}
+    answered = sum(1 for q in ctx.plan.questions if q.id in answered_ids)
+    return answered / total
+
+
 def _competency_lines(comp_scores: list[CompetencyScore]) -> str:
     if not comp_scores:
         return "- (no competencies scored)"
@@ -102,4 +117,5 @@ async def generate_report(
         next_steps=narrative.next_steps,
         language_report=lang_report,
         summary=narrative.summary,
+        coverage_pct=_coverage_pct(ctx),
     )

--- a/apps/agent/src/deepinterview_agent/shared_models.py
+++ b/apps/agent/src/deepinterview_agent/shared_models.py
@@ -203,6 +203,12 @@ class ScoreCard(BaseModel):
     next_steps: list[str]
     language_report: LanguageReport
     summary: str
+    # Fraction of planned questions actually answered (0.0-1.0). Lets consumers
+    # distinguish a low score caused by a short/aborted interview from genuinely
+    # weak answers; unanswered questions are excluded from overall_score and
+    # weak_competencies. Defaults to 1.0 for backward compatibility with
+    # scorecards persisted before this field existed.
+    coverage_pct: float = 1.0
 
 
 # --- interview context -------------------------------------------------------

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -29,6 +29,7 @@ from .core.config import get_settings
 from .core.deps import build_deps
 from .core.logging import get_logger
 from .live.director import Director
+from .live.guard import SessionGuard
 from .live.interviewer import Interviewer
 from .live.state import InterviewUserdata
 from .shared_models import InterviewContext, RoomMetadata, ScoreRequest
@@ -168,7 +169,18 @@ async def entrypoint(ctx: JobContext) -> None:
     director = Director(userdata)
     director.start()
 
+    # Hard in-room cost/duration backstop (Golden Rule #5): ends the session if
+    # it runs past the configured ceilings, independent of the web-layer cap on
+    # interview creation. Started after the session is live (see below).
+    guard = SessionGuard(
+        session,
+        userdata,
+        max_duration_sec=settings.max_interview_duration_sec,
+        max_turns=settings.max_interview_turns,
+    )
+
     async def _on_shutdown() -> None:
+        await guard.aclose()
         await director.aclose()
         # Persist whatever was captured, best-effort, off the turn path.
         try:
@@ -192,6 +204,10 @@ async def entrypoint(ctx: JobContext) -> None:
         agent=Interviewer(userdata),
         room=ctx.room,
     )
+
+    # Start the guard only once the session is live (it calls session.say /
+    # session.shutdown); it runs detached until a ceiling trips or shutdown.
+    guard.start()
 
 
 def main() -> None:

--- a/apps/agent/tests/test_guard.py
+++ b/apps/agent/tests/test_guard.py
@@ -1,0 +1,113 @@
+"""Offline tests for the live SessionGuard (WP-5 cost/duration backstop).
+
+The guard talks to the session through a tiny duck-typed surface (``say`` /
+``shutdown``) and takes an injectable clock, so these run with a fake session
+and a fake clock — no livekit, no real time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from deepinterview_agent.live.guard import SessionGuard
+
+
+class _FakeSession:
+    """Records the guard's say/shutdown calls."""
+
+    def __init__(self) -> None:
+        self.said: list[str] = []
+        self.shutdown_called = False
+        self.drain: bool | None = None
+
+    async def say(self, text: str) -> None:
+        self.said.append(text)
+
+    def shutdown(self, *, drain: bool = True) -> None:
+        self.shutdown_called = True
+        self.drain = drain
+
+
+def _ud(turns: int = 0, session_id: str = "sess_test") -> SimpleNamespace:
+    return SimpleNamespace(transcript=[{"role": "user", "text": "x"}] * turns, session_id=session_id)
+
+
+async def _drive(guard: SessionGuard) -> None:
+    """Start the guard and wait for its background task to finish."""
+    guard.start()
+    assert guard._task is not None
+    await guard._task
+
+
+def test_limit_reached_is_pure() -> None:
+    guard = SessionGuard(_FakeSession(), _ud(), max_duration_sec=10, max_turns=3)
+    assert guard._limit_reached(5.0) is None
+    assert guard._limit_reached(10.0) is not None  # duration ceiling (>=)
+    guard_turns = SessionGuard(_FakeSession(), _ud(turns=3), max_duration_sec=10_000, max_turns=3)
+    assert guard_turns._limit_reached(0.0) is not None  # turn ceiling
+
+
+def test_guard_trips_on_duration() -> None:
+    session = _FakeSession()
+    ticks = iter([0.0] + [100.0] * 10)  # start at 0, then elapsed >> max
+    guard = SessionGuard(
+        session, _ud(), max_duration_sec=10, max_turns=10_000,
+        interval_sec=0.0, time_fn=lambda: next(ticks),
+    )
+    asyncio.run(_drive(guard))
+
+    assert guard.tripped
+    assert session.shutdown_called
+    assert session.drain is True
+    assert session.said, "guard should say a closing line before shutting down"
+
+
+def test_guard_trips_on_turns() -> None:
+    session = _FakeSession()
+    guard = SessionGuard(
+        session, _ud(turns=5), max_duration_sec=10_000, max_turns=5,
+        interval_sec=0.0, time_fn=lambda: 0.0,
+    )
+    asyncio.run(_drive(guard))
+
+    assert guard.tripped
+    assert session.shutdown_called
+
+
+def test_guard_does_not_trip_under_limits_and_closes_cleanly() -> None:
+    session = _FakeSession()
+    guard = SessionGuard(
+        session, _ud(), max_duration_sec=10_000, max_turns=10_000,
+        interval_sec=0.01, time_fn=lambda: 0.0,
+    )
+
+    async def _scenario() -> None:
+        guard.start()
+        await asyncio.sleep(0.0)  # let one iteration run (then it sleeps)
+        await guard.aclose()  # cancel cleanly
+
+    asyncio.run(_scenario())
+
+    assert not guard.tripped
+    assert not session.shutdown_called
+    assert not session.said
+
+
+def test_wrap_up_is_best_effort_when_session_raises() -> None:
+    """A session whose say()/shutdown() raise must not crash the guard."""
+
+    class _AngrySession:
+        async def say(self, text: str) -> None:
+            raise RuntimeError("say failed")
+
+        def shutdown(self, *, drain: bool = True) -> None:
+            raise RuntimeError("shutdown failed")
+
+    guard = SessionGuard(
+        _AngrySession(), _ud(), max_duration_sec=0, max_turns=10_000,
+        interval_sec=0.0, time_fn=lambda: 0.0,
+    )
+    # Should complete without propagating the session's exceptions.
+    asyncio.run(_drive(guard))
+    assert guard.tripped

--- a/apps/agent/tests/test_score.py
+++ b/apps/agent/tests/test_score.py
@@ -150,4 +150,45 @@ def test_run_score_handles_missing_context() -> None:
     assert sc.competency_scores == []
     assert sc.weak_competencies == []
     assert sc.overall_score == 0.0
+    assert sc.coverage_pct == 0.0
     assert ScoreCard.model_validate(sc.model_dump()) == sc
+
+
+def test_run_score_reports_partial_coverage() -> None:
+    """Unanswered questions lower coverage_pct and never count as weak."""
+    deps = build_deps()
+    session_id, ctx = _prepare_session(deps)  # seeds 3 answers
+
+    sc = asyncio.run(run_score(ScoreRequest(session_id=session_id), deps))
+
+    answered_ids = {a.question_id for a in ctx.answers if a.transcript and a.transcript.strip()}
+    total = len(ctx.plan.questions)
+    expected = len(answered_ids) / total if total else 1.0
+    assert abs(sc.coverage_pct - expected) < 1e-9
+
+    # A competency we never probed must not appear as weak or even as a score.
+    answered_comps = {q.target_competency for q in ctx.plan.questions if q.id in answered_ids}
+    assert set(sc.weak_competencies) <= answered_comps
+    assert {cs.competency for cs in sc.competency_scores} <= answered_comps
+
+
+def test_run_score_degrades_when_a_stage_fails(monkeypatch) -> None:
+    """A failing scoring stage yields a valid, persisted, COMPLETE scorecard."""
+    deps = build_deps()
+    session_id, _ctx = _prepare_session(deps)
+
+    import deepinterview_agent.post as post
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("provider exploded")
+
+    # Competency evaluation blows up; run_score must still return a valid card,
+    # persist it, and mark the session complete — never raise or leave it stuck.
+    monkeypatch.setattr(post, "evaluate", _boom)
+
+    sc = asyncio.run(run_score(ScoreRequest(session_id=session_id), deps))
+
+    assert isinstance(sc, ScoreCard)
+    assert sc.competency_scores == []  # evaluation degraded to empty
+    assert ScoreCard.model_validate(sc.model_dump()) == sc
+    assert deps.repo.get_status(session_id) == "complete"

--- a/apps/web/lib/sample-scorecard.ts
+++ b/apps/web/lib/sample-scorecard.ts
@@ -18,6 +18,7 @@ import {
  */
 export const SAMPLE_SCORECARD: ScoreCard = {
   overall_score: 3.6,
+  coverage_pct: 1.0,
   competency_scores: [
     {
       competency: "Communication",

--- a/packages/shared/schema/InterviewContext.json
+++ b/packages/shared/schema/InterviewContext.json
@@ -639,6 +639,10 @@
             },
             "summary": {
               "type": "string"
+            },
+            "coverage_pct": {
+              "default": 1,
+              "type": "number"
             }
           },
           "required": [

--- a/packages/shared/schema/ScoreCard.json
+++ b/packages/shared/schema/ScoreCard.json
@@ -114,6 +114,10 @@
     },
     "summary": {
       "type": "string"
+    },
+    "coverage_pct": {
+      "default": 1,
+      "type": "number"
     }
   },
   "required": [

--- a/packages/shared/schema/ScoreResponse.json
+++ b/packages/shared/schema/ScoreResponse.json
@@ -120,6 +120,10 @@
         },
         "summary": {
           "type": "string"
+        },
+        "coverage_pct": {
+          "default": 1,
+          "type": "number"
         }
       },
       "required": [

--- a/packages/shared/src/samples.ts
+++ b/packages/shared/src/samples.ts
@@ -178,6 +178,7 @@ export const SAMPLE_INTERVIEW_CONTEXT: InterviewContext = {
   ],
   scorecard: {
     overall_score: 78.5,
+    coverage_pct: 1.0,
     competency_scores: [
       {
         competency: "technical_leadership",

--- a/packages/shared/src/score.ts
+++ b/packages/shared/src/score.ts
@@ -35,5 +35,10 @@ export const ScoreCardSchema = z.object({
   next_steps: z.array(z.string()),
   language_report: LanguageReportSchema,
   summary: z.string(),
+  // Fraction of planned questions actually answered (0.0-1.0). Unanswered
+  // questions are excluded from overall_score and weak_competencies; this lets
+  // consumers tell a short/aborted interview apart from genuinely weak answers.
+  // Defaults to 1.0 for scorecards persisted before this field existed.
+  coverage_pct: z.number().default(1.0),
 });
 export type ScoreCard = z.infer<typeof ScoreCardSchema>;


### PR DESCRIPTION
Merges `feat/interview-resilience-fixes` into `main`, with the conflicts against the merged Study Coach line resolved on this branch (so this PR is cleanly mergeable — no conflicts shown in GitHub).

## What this brings in
- **Live cost/duration guard** (`SessionGuard`) — caps interview wall-clock + turn count so a stalled/looping live room can't run unbounded (Golden Rule #5).
- **Fail-soft scoring** — each `post` stage (evaluate / coach / report) runs with a timeout + structured fallback; the scorecard is always persisted and the session marked `complete` (a transient model error no longer 500s and discards the interview).
- **`coverage_pct`** on `ScoreCard` — unanswered questions are skipped in scoring, so a short/aborted interview is distinguishable from genuinely weak answers.
- **Skill distiller hook** in `run_score` (gated, off by default).

## Conflict resolution
- `post/__init__.py` `run_score`: combined the fail-soft per-stage guards with the existing gated adversarial verifier (`enable_score_verifier`) — verifier runs guarded between evaluate and coach.
- `core/config.py`: kept **both** flag sets (cost-guard + distiller AND coach/adaptive/verifier).
- `shared_models.py` / `worker.py`: auto-merged cleanly (`coverage_pct` + coach models coexist; `SessionGuard` + adaptive `Director` coexist).
- Regenerated Zod schemas (32) for cross-language parity.

## Verification
- Agent suite: **127 passed**, ruff clean.
- Shared: build + vitest (6) + typecheck.
- Web: typecheck 0 errors.