### PR TITLE
fix(report): show real data — stamp session owner + persist live answers

### DIFF
--- a/apps/agent/src/deepinterview_agent/core/persistence/repository.py
+++ b/apps/agent/src/deepinterview_agent/core/persistence/repository.py
@@ -57,6 +57,9 @@ class SessionRepository(Protocol):
 class _SessionRow:
     id: str
     status: str = "prep"
+    # Owning user (Supabase auth uid); None for the offline/dev path. Stamped so
+    # the web report's RLS read (auth.uid() = user_id) can see the row.
+    user_id: str | None = None
     company: str | None = None
     cv_url: str | None = None
     jd_text: str | None = None
@@ -80,6 +83,7 @@ class MemoryRepository:
         self._rows[session_id] = _SessionRow(
             id=session_id,
             status="prep",
+            user_id=req.user_id,
             company=req.company,
             cv_url=req.cv_url,
             jd_text=req.jd_text,
@@ -183,6 +187,9 @@ class SupabaseRepository:
         payload = {
             "id": session_id,
             "status": "prep",
+            # Stamp the owner so the web report's RLS read (auth.uid() = user_id)
+            # can see this row. None on the offline/dev path (column is nullable).
+            "user_id": req.user_id,
             "company": req.company,
             "cv_url": req.cv_url,
             "jd_text": req.jd_text,

--- a/apps/agent/src/deepinterview_agent/shared_models.py
+++ b/apps/agent/src/deepinterview_agent/shared_models.py
@@ -295,6 +295,10 @@ class PrepRequest(BaseModel):
     jd_text: str
     company: str
     language_mode: LanguageMode
+    # Owning user (Supabase auth uid). Optional so the offline/dev path (no auth)
+    # still validates; when present it is stamped on the `sessions` row so the
+    # report's RLS read (auth.uid() = user_id) can see the row. Mirrors api.ts.
+    user_id: str | None = None
 
 
 class PrepResponse(BaseModel):

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -189,6 +189,16 @@ async def entrypoint(ctx: JobContext) -> None:
             await deps.repo.save_transcript(session_id, userdata.transcript)
         except Exception:  # noqa: BLE001
             log.exception("worker: save_transcript failed for %s", session_id)
+        # The live loop only mutates the IN-MEMORY userdata.ctx (an AnswerRecord
+        # is appended per answered turn — see live/state.py). Write that context
+        # back BEFORE triggering scoring, or run_score -> load_context reads the
+        # prep-time (answer-less) context and produces a blank scorecard
+        # (coverage 0%). Effective when both processes share a Supabase store
+        # (the in-memory repo is process-local; same caveat as the load path).
+        try:
+            await deps.repo.save_context(session_id, userdata.ctx)
+        except Exception:  # noqa: BLE001
+            log.exception("worker: save_context failed for %s", session_id)
         # Fire scoring (WP-7) best-effort; never block shutdown on it.
         api_base = f"http://localhost:{settings.agent_api_port}"
         try:

--- a/apps/web/app/setup/actions.ts
+++ b/apps/web/app/setup/actions.ts
@@ -75,7 +75,14 @@ export async function startSession(
 
   let session_id: string;
   try {
-    ({ session_id } = await requestPrep(input));
+    // Forward the signed-in user's id so the agent stamps it on the `sessions`
+    // row (sessions.user_id). Without this the row is unowned (NULL) and the
+    // report's RLS read (auth.uid() = user_id) can never see it, so the page
+    // falls back to sample data. Offline/dev has no user → omit it.
+    ({ session_id } = await requestPrep({
+      ...input,
+      user_id: userId ?? undefined,
+    }));
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Could not reach the prep service.";

--- a/packages/shared/schema/PrepRequest.json
+++ b/packages/shared/schema/PrepRequest.json
@@ -37,6 +37,9 @@
         "primary",
         "mixed"
       ]
+    },
+    "user_id": {
+      "type": "string"
     }
   },
   "required": [

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -8,6 +8,10 @@ export const PrepRequestSchema = z.object({
   jd_text: z.string(),
   company: z.string(),
   language_mode: LanguageModeSchema,
+  // Owning user (Supabase auth uid). Optional so the offline/dev path (no auth)
+  // still validates; when present the agent stamps it on the `sessions` row so
+  // the report's RLS read (`auth.uid() = user_id`) can see the row.
+  user_id: z.string().optional(),
 });
 export type PrepRequest = z.infer<typeof PrepRequestSchema>;
 


### PR DESCRIPTION
## What

The post-interview report always fell back to **"Preview (sample data)"** — even with Supabase + a real LLM configured. Two independent breaks, both fixed here:

1. **Unowned session rows (RLS).** `create_session` inserted `sessions.user_id = NULL`; the report reads via the anon client under RLS `auth.uid() = user_id`, so the row was never visible and the page silently rendered the sample scorecard. `user_id` is now threaded through `PrepRequest` (zod + Pydantic parity), forwarded from the web setup action, and stamped on insert.
2. **Live answers never persisted.** Answers were only appended to the in-memory `userdata.ctx`; the worker saved the transcript but not the context, so `run_score` → `load_context` read the prep-time (answer-less) context and produced a blank scorecard (coverage 0%). The worker now persists `save_context(...)` on shutdown **before** triggering scoring.

Also regenerates `packages/shared/schema/PrepRequest.json` from the zod registry.

## Verification
- `packages/shared`: build + typecheck + 6 tests ✅
- agent: 134 tests incl. cross-language `test_parity` ✅
- web typecheck ✅ · prettier + ruff clean ✅

## Notes
- Branched off `origin/main`; contains only these 6 files (no unrelated work-in-progress).
- Out of scope (follow-up): a "scoring in progress" report state so visiting `/report/[id]` before shutdown-scoring finishes isn't indistinguishable from sample.
