### PR TITLE
chore: isolate agent tests from real .env + prettier nits

### DIFF
--- a/apps/agent/tests/conftest.py
+++ b/apps/agent/tests/conftest.py
@@ -10,8 +10,12 @@ and turning a 4-second suite into a multi-minute one that hammers the live key.
 We force every provider to ``mock`` via ``os.environ`` BEFORE any test imports
 ``get_settings()`` (whose result is ``lru_cache``d). ``os.environ`` takes precedence
 over ``.env`` in pydantic-settings, so this restores the documented offline contract
-regardless of what ``.env`` contains. Set ``DEEPINTERVIEW_TEST_USE_ENV=1`` to opt out
-(e.g. a deliberate live integration run).
+regardless of what ``.env`` contains. We likewise BLANK the Supabase creds so
+``get_repository()`` falls back to the in-memory repo: a real ``.env`` now ships a
+Supabase URL + service-role key, and without this the suite would select
+``SupabaseRepository`` and fail on the optional ``supabase`` SDK (not installed in
+the test venv). Set ``DEEPINTERVIEW_TEST_USE_ENV=1`` to opt out (e.g. a deliberate
+live integration run).
 """
 
 from __future__ import annotations
@@ -27,3 +31,8 @@ if os.environ.get("DEEPINTERVIEW_TEST_USE_ENV") != "1":
         "EMBEDDINGS_PROVIDER",
     ):
         os.environ[_var] = "mock"
+    # Empty string overrides ``.env`` and is falsy, so the
+    # ``settings.supabase_url and settings.supabase_service_role_key`` guard in
+    # ``get_repository()`` is False → deterministic in-memory ``MemoryRepository``.
+    for _var in ("SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"):
+        os.environ[_var] = ""

--- a/apps/web/app/api/coach/chat/route.ts
+++ b/apps/web/app/api/coach/chat/route.ts
@@ -35,7 +35,10 @@ function mockReply(query: string): CoachReply {
         snippet: "Relevant guidance for this topic from your materials.",
       },
     ],
-    follow_ups: ["Can you give a concrete example?", "What's a common mistake here?"],
+    follow_ups: [
+      "Can you give a concrete example?",
+      "What's a common mistake here?",
+    ],
   };
 }
 
@@ -44,7 +47,10 @@ export async function POST(request: Request) {
   try {
     body = BodySchema.parse(await request.json());
   } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
   }
 
   try {
@@ -65,7 +71,9 @@ export async function POST(request: Request) {
     const json = await upstream.json();
     const parsed = CoachReplySchema.safeParse(json);
     // Validate the upstream shape; fall back to a mock on drift.
-    return NextResponse.json(parsed.success ? parsed.data : mockReply(body.query));
+    return NextResponse.json(
+      parsed.success ? parsed.data : mockReply(body.query),
+    );
   } catch {
     // Agent unreachable / timeout / bad JSON — stay resilient.
     return NextResponse.json(mockReply(body.query));

--- a/apps/web/components/setup/setup-form.tsx
+++ b/apps/web/components/setup/setup-form.tsx
@@ -108,7 +108,8 @@ export function SetupForm({ r2Configured }: { r2Configured: boolean }) {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result as string);
-      reader.onerror = () => reject(reader.error ?? new Error("Could not read file."));
+      reader.onerror = () =>
+        reject(reader.error ?? new Error("Could not read file."));
       reader.readAsDataURL(f);
     });
   }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -47,5 +47,7 @@ export function requestScore(body: ScoreRequest): Promise<ScoreResponse> {
 
 /** Build a Study Coach plan from a scorecard's weak competencies (server-side). */
 export function requestCoachPlan(scorecard: ScoreCard): Promise<StudyPlan> {
-  return postJson("/api/coach/plan", { scorecard }, (d) => StudyPlanSchema.parse(d));
+  return postJson("/api/coach/plan", { scorecard }, (d) =>
+    StudyPlanSchema.parse(d),
+  );
 }


### PR DESCRIPTION
Makes the agent test suite hermetic against a real `apps/agent/.env` (blank Supabase creds during tests → in-memory repo) and reformats 3 prettier-flagged files. Restores 135/135 agent tests with live keys present; `pnpm lint` green. No runtime/behavior change.