### PR TITLE
feat(oss): auth-free report via the agent API

### DIFF
--- a/apps/agent/src/deepinterview_agent/api/views.py
+++ b/apps/agent/src/deepinterview_agent/api/views.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ..shared_models import InterviewContext
+from ..shared_models import InterviewContext, ScoreCard
 
 __all__ = ["SessionView", "SessionStatus", "PROGRESS_STEPS"]
 
@@ -42,3 +42,7 @@ class SessionView(BaseModel):
     progress: list[str] = Field(default_factory=list)
     prep_warnings: list[str] = Field(default_factory=list)
     context: InterviewContext | None = None
+    # The assembled scorecard once post-interview scoring has run (status
+    # "complete"). Surfaced here so the web report can read it through the agent
+    # API — no Supabase/RLS/auth on the read path (OSS runs without sign-in).
+    scorecard: ScoreCard | None = None

--- a/apps/agent/src/deepinterview_agent/core/persistence/repository.py
+++ b/apps/agent/src/deepinterview_agent/core/persistence/repository.py
@@ -138,12 +138,16 @@ class MemoryRepository:
         context = (
             InterviewContext.model_validate(row.context) if row.context else None
         )
+        scorecard = (
+            ScoreCard.model_validate(row.scorecard) if row.scorecard else None
+        )
         return SessionView(
             session_id=row.id,
             status=row.status,
             progress=list(row.progress),
             prep_warnings=list(row.warnings),
             context=context,
+            scorecard=scorecard,
         )
 
     # --- test / inspection helpers (not part of the protocol) ----------------
@@ -264,7 +268,7 @@ class SupabaseRepository:
         def _build() -> Any:
             return (
                 self._table()
-                .select("id,status,progress,prep_warnings,context")
+                .select("id,status,progress,prep_warnings,context,scorecard")
                 .eq("id", session_id)
                 .limit(1)
                 .execute()
@@ -277,12 +281,15 @@ class SupabaseRepository:
         row = rows[0]
         ctx_data = row.get("context")
         context = InterviewContext.model_validate(ctx_data) if ctx_data else None
+        sc_data = row.get("scorecard")
+        scorecard = ScoreCard.model_validate(sc_data) if sc_data else None
         return SessionView(
             session_id=row["id"],
             status=row.get("status", "prep"),
             progress=list(row.get("progress") or []),
             prep_warnings=list(row.get("prep_warnings") or []),
             context=context,
+            scorecard=scorecard,
         )
 
     async def _update(self, session_id: str, values: dict[str, Any]) -> None:

--- a/apps/web/app/report/[id]/page.tsx
+++ b/apps/web/app/report/[id]/page.tsx
@@ -1,13 +1,7 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import {
-  ScoreCardSchema,
-  InterviewContextSchema,
-  type ScoreCard,
-  type InterviewContext,
-} from "@deepinterview/shared";
-import { isSupabaseConfigured } from "@/lib/env";
-import { createClient, getUser } from "@/lib/supabase/server";
+import { type ScoreCard, type InterviewContext } from "@deepinterview/shared";
+import { serverEnv } from "@/lib/env";
+import { SessionViewSchema } from "@/lib/session";
 import { SAMPLE_SCORECARD, SAMPLE_INTERVIEW } from "@/lib/sample-scorecard";
 import { Eyebrow } from "@/components/ui/eyebrow";
 import { Badge } from "@/components/ui/badge";
@@ -29,7 +23,7 @@ import {
   type TranscriptTurn,
 } from "@/components/report/transcript-section";
 
-// Reads server-only config and a per-request DB row; never prerender.
+// Reads server-only config and calls the agent API per request; never prerender.
 export const dynamic = "force-dynamic";
 
 interface Loaded {
@@ -42,10 +36,11 @@ interface Loaded {
 }
 
 /**
- * Resolve the scorecard for this session. When Supabase is configured we fetch
- * the `sessions` row and zod-parse `row.scorecard` (+ `row.context` for the
- * transcript); on any miss — unconfigured, no row, bad shape — we fall back to
- * the sample so the report always renders (offline-safe).
+ * Resolve the scorecard for this session by reading the agent API
+ * (`GET /api/session/{id}` → SessionView, which carries `scorecard` + `context`).
+ * No Supabase / RLS / auth on the read path, so OSS works without sign-in. On
+ * any miss — agent down, not scored yet, bad shape — we fall back to the sample
+ * so the report always renders.
  */
 async function load(id: string): Promise<Loaded> {
   const fallback: Loaded = {
@@ -56,32 +51,32 @@ async function load(id: string): Promise<Loaded> {
     role: SAMPLE_INTERVIEW.role,
   };
 
-  if (!isSupabaseConfigured()) return fallback;
+  // Read the scorecard through the agent API (which owns persistence) — no
+  // Supabase / RLS / auth on the read path, so OSS works without sign-in. Any
+  // miss (agent down, not scored yet, bad shape) falls back to the sample.
+  try {
+    const res = await fetch(
+      `${serverEnv.agentApiUrl}/api/session/${encodeURIComponent(id)}`,
+      { cache: "no-store", signal: AbortSignal.timeout(15_000) },
+    );
+    if (!res.ok) return fallback;
 
-  const supabase = await createClient();
-  if (!supabase) return fallback;
+    const parsed = SessionViewSchema.safeParse(await res.json());
+    if (!parsed.success) return fallback;
 
-  const { data, error } = await supabase
-    .from("sessions")
-    .select("scorecard, context, company")
-    .eq("id", id)
-    .maybeSingle();
+    const view = parsed.data;
+    if (!view.scorecard) return fallback;
 
-  if (error || !data) return fallback;
-
-  const parsed = ScoreCardSchema.safeParse(data.scorecard);
-  if (!parsed.success) return fallback;
-
-  const ctxParsed = InterviewContextSchema.safeParse(data.context);
-  const context = ctxParsed.success ? ctxParsed.data : null;
-
-  return {
-    scorecard: parsed.data,
-    context,
-    isSample: false,
-    company: context?.job.company_name ?? data.company ?? null,
-    role: context?.job.title ?? null,
-  };
+    return {
+      scorecard: view.scorecard,
+      context: view.context,
+      isSample: false,
+      company: view.context?.job.company_name ?? null,
+      role: view.context?.job.title ?? null,
+    };
+  } catch {
+    return fallback;
+  }
 }
 
 /** Build the question-text lookup + ordered transcript turns. */
@@ -130,12 +125,8 @@ export default async function ReportPage({
 }) {
   const { id } = await params;
 
-  // Page-level auth: gate only when Supabase is wired up; offline we proceed.
-  if (isSupabaseConfigured()) {
-    const user = await getUser();
-    if (!user) redirect("/login");
-  }
-
+  // No auth gate: OSS reads the report through the agent API, which needs no
+  // sign-in. (Hosted/multi-tenant deployments add auth as a separate layer.)
   const loaded = await load(id);
   const { scorecard } = loaded;
   const { questionText, turns } = buildTranscript(loaded);

--- a/apps/web/app/setup/actions.ts
+++ b/apps/web/app/setup/actions.ts
@@ -39,12 +39,14 @@ export async function startSession(
   let profile: ProfileBilling | null = null;
 
   if (configured) {
+    // OSS runs without sign-in: an anonymous user proceeds with no billing /
+    // gating. A signed-in user (hosted) still gets the metered cap enforced
+    // below — `supabase` stays null when anonymous, so that block is skipped.
     const user = await getUser();
-    if (!user) {
-      return { ok: false, error: "Please sign in to start an interview." };
+    if (user) {
+      userId = user.id;
+      supabase = await createClient();
     }
-    userId = user.id;
-    supabase = await createClient();
 
     // Load the billing-relevant profile row and roll the monthly period if due.
     if (supabase) {

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { InterviewContextSchema } from "@deepinterview/shared";
+import { InterviewContextSchema, ScoreCardSchema } from "@deepinterview/shared";
 
 /**
  * Client/server-shared view of a prep session as exposed by the agent
@@ -15,6 +15,9 @@ export const SessionViewSchema = z.object({
   progress: z.array(z.string()),
   prep_warnings: z.array(z.string()),
   context: InterviewContextSchema.nullable(),
+  // Present once post-interview scoring has run; the report reads it from here
+  // (via the agent API) so no Supabase/auth is needed on the read path.
+  scorecard: ScoreCardSchema.nullish(),
 });
 export type SessionView = z.infer<typeof SessionViewSchema>;
 
@@ -47,6 +50,7 @@ function preparingFallback(id: string): SessionView {
     progress: [],
     prep_warnings: [],
     context: null,
+    scorecard: null,
   };
 }
 


### PR DESCRIPTION
Makes the OSS build work without sign-in. The web report now reads through the agent API (`GET /api/session/{id}`, which carries `scorecard` + `context`) instead of querying Supabase directly under RLS, and the `/login` gate is removed; setup no longer requires sign-in. Auth + RLS + billing remain available as a hosted-only layer. Verified: web typecheck + build, agent 135/135, ruff, prettier.