### PR TITLE
feat: localized voice routing + one-click demo samples

### DIFF
--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -42,12 +42,25 @@ log = get_logger(__name__)
 # fallback when the selected provider's key is missing (English-first defaults).
 
 
-def build_stt(settings):  # noqa: ANN001, ANN201 - livekit plugin types optional
+# Map our primary-language code onto the speech providers so STT transcribes —
+# and TTS speaks — in the candidate's language, not just English. Deepgram
+# nova-3 and Cartesia sonic-3 are multilingual; codes default to English when a
+# language isn't mapped. `mixed` (code-switching) uses Deepgram's "multi" model.
+_STT_LANG = {"en": "en", "vi": "vi", "es": "es", "zh": "zh", "fr": "fr", "de": "de", "ja": "ja"}
+_TTS_LANG = {"en": "en", "vi": "vi", "es": "es", "zh": "zh", "fr": "fr", "de": "de", "ja": "ja"}
+
+
+def _stt_lang(language: str, mixed: bool) -> str:
+    return "multi" if mixed else _STT_LANG.get(language, "en")
+
+
+def build_stt(settings, language="en", mixed=False):  # noqa: ANN001, ANN201 - livekit plugin types optional
+    lang = _stt_lang(language, mixed)
     provider = settings.stt_provider
     if provider == "deepgram" and settings.deepgram_api_key:
         from livekit.plugins import deepgram  # noqa: PLC0415
 
-        return deepgram.STT(api_key=settings.deepgram_api_key, language="en")
+        return deepgram.STT(api_key=settings.deepgram_api_key, language=lang)
     if provider == "soniox" and settings.soniox_api_key:
         from livekit.plugins import soniox  # noqa: PLC0415
 
@@ -55,7 +68,7 @@ def build_stt(settings):  # noqa: ANN001, ANN201 - livekit plugin types optional
     log.warning("build_stt: no configured STT provider/key; using Deepgram default")
     from livekit.plugins import deepgram  # noqa: PLC0415
 
-    return deepgram.STT()
+    return deepgram.STT(language=lang)
 
 
 def build_llm(settings):  # noqa: ANN001, ANN201
@@ -75,20 +88,22 @@ def build_llm(settings):  # noqa: ANN001, ANN201
     return openai.LLM()
 
 
-def build_tts(settings):  # noqa: ANN001, ANN201
+def build_tts(settings, language="en"):  # noqa: ANN001, ANN201
+    lang = _TTS_LANG.get(language, "en")
     provider = settings.tts_provider
     if provider == "cartesia" and settings.cartesia_api_key:
         from livekit.plugins import cartesia  # noqa: PLC0415
 
-        return cartesia.TTS(api_key=settings.cartesia_api_key)
+        return cartesia.TTS(api_key=settings.cartesia_api_key, language=lang)
     if provider == "elevenlabs" and settings.elevenlabs_api_key:
         from livekit.plugins import elevenlabs  # noqa: PLC0415
 
+        # ElevenLabs' multilingual model infers the language from the text.
         return elevenlabs.TTS(api_key=settings.elevenlabs_api_key)
     log.warning("build_tts: no configured TTS provider/key; using Cartesia default")
     from livekit.plugins import cartesia  # noqa: PLC0415
 
-    return cartesia.TTS()
+    return cartesia.TTS(language=lang)
 
 
 def build_vad():  # noqa: ANN201
@@ -155,11 +170,14 @@ async def entrypoint(ctx: JobContext) -> None:
 
     userdata = InterviewUserdata(ctx=interview_ctx, session_id=session_id)
 
+    # Route STT/TTS by the interview's primary language so a non-English session
+    # (e.g. Vietnamese) is both understood and spoken — not just prompted for.
+    lang_mode = interview_ctx.plan.language_mode
     session: AgentSession[InterviewUserdata] = AgentSession(
         userdata=userdata,
-        stt=build_stt(settings),
+        stt=build_stt(settings, lang_mode.primary, lang_mode.mixed),
         llm=build_llm(settings),
-        tts=build_tts(settings),
+        tts=build_tts(settings, lang_mode.primary),
         vad=build_vad(),
         # Lean live loop: low-latency turns. Turn detection is on by default in
         # 1.x; preemptive generation starts the LLM before end-of-turn settles.

--- a/apps/web/components/setup/setup-form.tsx
+++ b/apps/web/components/setup/setup-form.tsx
@@ -48,6 +48,33 @@ type Step = { key: string; label: string };
 const MIN_JD_CHARS = 40;
 const MIN_CV_CHARS = 30;
 
+// One-click sample inputs for fast testing / demos. Each is a matched CV + JD +
+// company so the prep pipeline gets a coherent pair. Pure UX sugar — clicking a
+// sample just fills the form fields; nothing is submitted.
+const SAMPLES = [
+  {
+    id: "backend",
+    label: "Backend Engineer · Stripe",
+    company: "Stripe",
+    cv: "Jordan Rivera — Senior Backend Engineer. 7 years building high-throughput payment and API platforms. Led a ledger service at 5k req/s; cut p99 latency 40% with async batching; owned idempotency and reconciliation. Skills: Python, Go, PostgreSQL, Kafka, gRPC, Kubernetes, distributed systems.",
+    jd: "Senior Backend Engineer to build payment APIs at scale. Own services in Python/Go, design event-driven systems with Kafka, and ensure reliability, idempotency, and low p99 latency on PostgreSQL. Strong distributed-systems background required.",
+  },
+  {
+    id: "frontend",
+    label: "Frontend Engineer · Vercel",
+    company: "Vercel",
+    cv: "Sam Chen — Senior Frontend Engineer. 6 years shipping performant React/Next.js apps. Built a design system used across 30+ surfaces; improved LCP 35% with streaming SSR and image optimization. Skills: TypeScript, React, Next.js, Tailwind, accessibility, Core Web Vitals.",
+    jd: "Senior Frontend Engineer to build fast, delightful web experiences with Next.js and React. Own component architecture, Core Web Vitals, accessibility, and design-system work. Deep TypeScript and modern rendering (SSR/streaming) experience expected.",
+  },
+  {
+    id: "ml",
+    label: "ML Engineer · OpenAI",
+    company: "OpenAI",
+    cv: "Priya Nair — Machine Learning Engineer. 5 years in production ML: built feature pipelines and model serving for ranking at scale; owned offline/online evaluation and safe rollback. Skills: Python, PyTorch, Ray, feature stores, evaluation, MLOps, monitoring.",
+    jd: "Machine Learning Engineer to build and ship production ML systems: data pipelines, training, evaluation, and low-latency serving. You will own offline/online metrics, monitoring, and safe rollouts. Strong Python + PyTorch and MLOps experience required.",
+  },
+] as const;
+
 export function SetupForm({ r2Configured }: { r2Configured: boolean }) {
   const router = useRouter();
   const messages = useMessages();
@@ -91,6 +118,19 @@ export function SetupForm({ r2Configured }: { r2Configured: boolean }) {
         ? `Paste the full posting — this looks too short (at least ${MIN_JD_CHARS} characters).`
         : null;
   const canSubmit = !cvError && !jdError && !submitting;
+
+  // Fill the form with a matched sample (testing / demo). Clears any chosen file
+  // so the pasted sample CV text is what gets submitted.
+  function loadSample(s: (typeof SAMPLES)[number]) {
+    setFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    setCvText(s.cv);
+    setJdText(s.jd);
+    setCompany(s.company);
+    setCvTouched(false);
+    setJdTouched(false);
+    setError(null);
+  }
 
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -270,6 +310,30 @@ export function SetupForm({ r2Configured }: { r2Configured: boolean }) {
         </h1>
         <p className="mt-2 text-ink-soft">{t(messages, "setup.subtitle")}</p>
       </div>
+
+      {/* Quick demo: one-click sample CV + JD + company for fast testing */}
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-[13px] font-medium text-ink">Quick demo</p>
+            <p className="text-[12px] text-muted">
+              Load a matched sample CV + job description to try it fast.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {SAMPLES.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => loadSample(s)}
+                className="rounded-[10px] border border-line px-3 py-1.5 text-[12px] text-ink-soft transition-colors hover:border-ink"
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* CV */}
       <Card>


### PR DESCRIPTION
Two small features. (1) **Localized voice**: the live worker now routes STT (Deepgram) and TTS (Cartesia) by the interview's primary language, so non-English sessions (e.g. Vietnamese) are actually understood and spoken — STT was previously hardcoded to English; code-switching uses Deepgram's `multi` model. (2) **Demo samples**: a 'Quick demo' picker on /setup one-click fills a matched sample CV + JD + company for fast testing. Verified: agent 135/135, ruff, web typecheck+build, prettier.