### PR TITLE
feat(agent): Gemini TTS fallback for Cartesia-unsupported languages

### DIFF
--- a/apps/agent/src/deepinterview_agent/core/config.py
+++ b/apps/agent/src/deepinterview_agent/core/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     # livekit-plugins-google 1.5.x does not thread yet (-> 400 INVALID_ARGUMENT).
     # 2.5-flash-lite is low-latency and function-calls cleanly. Override: GEMINI_MODEL_LIVE.
     gemini_model_live: str = "gemini-2.5-flash-lite"
+    # Gemini native TTS — the fallback voice for languages Cartesia doesn't cover
+    # (e.g. Vietnamese). gemini-2.5-flash-preview-tts speaks 24 languages incl.
+    # vi-VN. Override via GEMINI_TTS_MODEL when a newer TTS model ships.
+    gemini_tts_model: str = "gemini-2.5-flash-preview-tts"
     # 2026-current OpenAI default. UNVERIFIED — no OpenAI key in this env; re-verify
     # the exact id + structured-output support before wiring billing (CLAUDE.md
     # golden rule #6). Env-overridable via OPENAI_MODEL.

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -88,9 +88,29 @@ def build_llm(settings):  # noqa: ANN001, ANN201
     return openai.LLM()
 
 
+# Languages Cartesia sonic speaks. Notably EXCLUDES Vietnamese — anything not in
+# this set falls back to Gemini TTS (gemini-2.5-flash-preview-tts covers 24
+# languages incl. vi-VN) when a Gemini key is available.
+_CARTESIA_LANGS = {"en", "es", "fr", "de", "ja", "zh", "pt", "hi", "it", "ko", "nl", "pl", "ru", "sv", "tr"}
+
+
 def build_tts(settings, language="en"):  # noqa: ANN001, ANN201
     lang = _TTS_LANG.get(language, "en")
     provider = settings.tts_provider
+
+    # An explicit ElevenLabs choice (multilingual) wins. Otherwise, for a
+    # language Cartesia can't speak (e.g. Vietnamese), fall back to Gemini TTS
+    # when a Gemini key is present — so vi is actually spoken, not mispronounced.
+    if (
+        provider != "elevenlabs"
+        and language not in _CARTESIA_LANGS
+        and settings.gemini_api_key
+    ):
+        from livekit.plugins.google.beta import GeminiTTS  # noqa: PLC0415
+
+        log.info("build_tts: %r unsupported by Cartesia; using Gemini TTS", language)
+        return GeminiTTS(model=settings.gemini_tts_model, api_key=settings.gemini_api_key)
+
     if provider == "cartesia" and settings.cartesia_api_key:
         from livekit.plugins import cartesia  # noqa: PLC0415
 


### PR DESCRIPTION
Cartesia Sonic doesn't speak Vietnamese. `build_tts` now falls back to Gemini native TTS (`gemini-2.5-flash-preview-tts`, 24 languages incl. vi-VN) for any language outside Cartesia's set, when a Gemini key is present; explicit ElevenLabs still wins. Adds `GEMINI_TTS_MODEL`. Verified: routing (vi→Gemini, en/ja→Cartesia), ruff, 135/135 tests.