### PR TITLE
fix(oss): remove remaining /login gates from the interview flow

### DIFF
--- a/apps/web/app/interview/[id]/page.tsx
+++ b/apps/web/app/interview/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import { isLiveKitConfigured, isSupabaseConfigured } from "@/lib/env";
 import { getUser } from "@/lib/supabase/server";
 import { createInterviewToken } from "@/lib/livekit";
@@ -31,14 +30,17 @@ export default async function InterviewPage({
   let identity = `dev-${id}`;
   let name: string | undefined;
 
+  // No auth gate (OSS): an anonymous visitor joins with a session-scoped dev
+  // identity. When a user IS signed in (hosted) we use their real identity.
   if (isSupabaseConfigured()) {
     const user = await getUser();
-    if (!user) redirect("/login");
-    identity = user.id;
-    name =
-      (user.user_metadata?.name as string | undefined) ??
-      user.email ??
-      undefined;
+    if (user) {
+      identity = user.id;
+      name =
+        (user.user_metadata?.name as string | undefined) ??
+        user.email ??
+        undefined;
+    }
   }
 
   const persona = getPersona(personaId);

--- a/apps/web/app/prep/page.tsx
+++ b/apps/web/app/prep/page.tsx
@@ -1,8 +1,5 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { RefreshCw, ArrowRight } from "lucide-react";
-import { isSupabaseConfigured } from "@/lib/env";
-import { getUser } from "@/lib/supabase/server";
 import { Eyebrow } from "@/components/ui/eyebrow";
 import { Button } from "@/components/ui/button";
 import { LanguageToggle } from "@/components/language-toggle";
@@ -30,12 +27,7 @@ export const dynamic = "force-dynamic";
  * content so the page renders fully with zero env keys.
  */
 export default async function PrepPage() {
-  // Page-level auth: gate only when Supabase is wired up; offline we proceed.
-  if (isSupabaseConfigured()) {
-    const user = await getUser();
-    if (!user) redirect("/login");
-  }
-
+  // No auth gate — OSS runs without sign-in.
   // Weak areas come from the last interview's scorecard (sample offline).
   const weakAreas = SAMPLE_SCORECARD.weak_competencies;
 

--- a/apps/web/app/session/[id]/page.tsx
+++ b/apps/web/app/session/[id]/page.tsx
@@ -1,6 +1,3 @@
-import { redirect } from "next/navigation";
-import { isSupabaseConfigured } from "@/lib/env";
-import { getUser } from "@/lib/supabase/server";
 import { PrepSummary } from "@/components/session/prep-summary";
 
 // Page-level auth + a per-request agent poll downstream; never prerender.
@@ -26,10 +23,7 @@ export default async function SessionPage({
   const { id } = await params;
   const { persona } = await searchParams;
 
-  if (isSupabaseConfigured()) {
-    const user = await getUser();
-    if (!user) redirect("/login");
-  }
-
+  // No auth gate — OSS runs without sign-in (the setup → prep → interview →
+  // report flow needs no login; hosted deployments add auth as a separate layer).
   return <PrepSummary sessionId={id} persona={persona ?? null} />;
 }


### PR DESCRIPTION
Completes PR #8. The session/interview/prep pages still had `redirect('/login')`, so an anonymous user was bounced to /login right after submitting setup (which routes to /session/[id]). Gates removed; the interview page still uses a signed-in user's identity when present. Verified: web typecheck + build, prettier.