### PR TITLE
fix(report): no more all-zeros report for answer-less interview sessions

### DIFF
--- a/apps/agent/src/deepinterview_agent/api/views.py
+++ b/apps/agent/src/deepinterview_agent/api/views.py
@@ -19,7 +19,13 @@ __all__ = ["SessionView", "SessionStatus", "PROGRESS_STEPS"]
 # "complete" is the terminal state set by the post-interview scoring step
 # (see post/__init__.py); it must be a valid status or GET /api/session/{id}
 # 500s on any read after an interview ends, blocking re-joins.
-SessionStatus = Literal["prep", "ready", "rejected", "error", "complete"]
+# "no_answers" is a terminal state for a session whose interview produced no
+# answers (ended without answering, or answers never persisted) — scoring is
+# skipped and no blank scorecard is written, so the UI can show an honest empty
+# state instead of a misleading all-zeros report.
+SessionStatus = Literal[
+    "prep", "ready", "rejected", "error", "complete", "no_answers"
+]
 
 # The canonical ordered set of prep steps a session progresses through. Reported
 # back as completed-step keys (a subset/permutation of these) in SessionView.

--- a/apps/agent/src/deepinterview_agent/post/__init__.py
+++ b/apps/agent/src/deepinterview_agent/post/__init__.py
@@ -69,6 +69,38 @@ def _missing_context_scorecard(session_id: str) -> ScoreCard:
     )
 
 
+def _no_answers_scorecard(session_id: str) -> ScoreCard:
+    """A valid, empty scorecard for a session that has a context but NO answers.
+
+    Returned (not persisted) so a direct ``/api/score`` caller always gets a
+    well-formed body. The session is flagged ``no_answers`` instead of
+    ``complete`` so the report can show an honest empty state rather than a
+    misleading all-zeros card.
+    """
+    return ScoreCard(
+        overall_score=0.0,
+        competency_scores=[],
+        strengths=[],
+        weaknesses=[],
+        weak_competencies=[],
+        model_answers=[],
+        next_steps=[],
+        language_report=LanguageReport(
+            fluency_score=0.0,
+            filler_word_count=0,
+            clarity_score=0.0,
+            code_switching_notes="",
+            pronunciation_notes="",
+            summary="No answers were recorded for this interview.",
+        ),
+        summary=(
+            f"No answers were recorded for session {session_id}; "
+            "the interview ended before any question was answered."
+        ),
+        coverage_pct=0.0,
+    )
+
+
 def _fallback_language_report() -> LanguageReport:
     """Neutral, well-formed language report used when the coach stage fails."""
     return LanguageReport(
@@ -157,6 +189,16 @@ async def run_score(req: ScoreRequest, deps: Deps) -> ScoreCard:
         # both an unknown session (nothing to write) and a prep-errored session
         # (don't overwrite its "error" status with "complete").
         return _missing_context_scorecard(req.session_id)
+
+    if not ctx.answers:
+        # A context exists but no answers were captured (interview ended before
+        # any question was answered, or answers never persisted). Do NOT run the
+        # LLM scoring stages or mark the session "complete" with a blank card —
+        # that yields a misleading all-zeros report. Flag it "no_answers" so the
+        # UI shows an honest empty state, and persist NO scorecard.
+        log.info("post: session %s has no answers; skipping scoring (no_answers)", req.session_id)
+        await deps.repo.update_status(req.session_id, "no_answers")
+        return _no_answers_scorecard(req.session_id)
 
     timeout = deps.settings.score_stage_timeout_sec
 

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -242,15 +242,43 @@ async def entrypoint(ctx: JobContext) -> None:
         except Exception:  # noqa: BLE001
             log.exception("worker: save_transcript failed for %s", session_id)
         # The live loop only mutates the IN-MEMORY userdata.ctx (an AnswerRecord
-        # is appended per answered turn — see live/state.py). Write that context
-        # back BEFORE triggering scoring, or run_score -> load_context reads the
-        # prep-time (answer-less) context and produces a blank scorecard
-        # (coverage 0%). Effective when both processes share a Supabase store
-        # (the in-memory repo is process-local; same caveat as the load path).
+        # is appended per answered turn — see live/state.py). Persist it BEFORE
+        # scoring; if persistence FAILS we must NOT score, or run_score ->
+        # load_context reads the prep-time (answer-less) context and produces a
+        # blank "complete" scorecard (coverage 0%). Both processes share the
+        # Supabase store (the in-memory repo is process-local; same caveat as the
+        # load path).
+        context_saved = False
         try:
             await deps.repo.save_context(session_id, userdata.ctx)
+            context_saved = True
         except Exception:  # noqa: BLE001
-            log.exception("worker: save_context failed for %s", session_id)
+            log.error(
+                "worker: save_context FAILED for %s — answers not persisted; "
+                "skipping scoring to avoid a blank scorecard",
+                session_id,
+                exc_info=True,
+            )
+
+        if not context_saved:
+            # Persistence failed: mark the session errored so the report shows an
+            # honest message rather than a misleading all-zeros card.
+            try:
+                await deps.repo.update_status(session_id, "error")
+            except Exception:  # noqa: BLE001
+                log.error("worker: update_status(error) failed for %s", session_id, exc_info=True)
+            return
+
+        if not userdata.ctx.answers:
+            # Interview produced no answers — record an honest terminal state and
+            # skip scoring entirely (no LLM calls, no blank "complete" card).
+            log.info("worker: session %s has no answers; marking no_answers (skip scoring)", session_id)
+            try:
+                await deps.repo.update_status(session_id, "no_answers")
+            except Exception:  # noqa: BLE001
+                log.error("worker: update_status(no_answers) failed for %s", session_id, exc_info=True)
+            return
+
         # Fire scoring (WP-7) best-effort; never block shutdown on it.
         api_base = f"http://localhost:{settings.agent_api_port}"
         try:

--- a/apps/agent/tests/test_score.py
+++ b/apps/agent/tests/test_score.py
@@ -154,6 +154,27 @@ def test_run_score_handles_missing_context() -> None:
     assert ScoreCard.model_validate(sc.model_dump()) == sc
 
 
+def test_run_score_skips_when_no_answers() -> None:
+    """A context that exists but has ZERO answers is flagged ``no_answers`` and
+    NOT scored into a misleading all-zeros ``complete`` card (the root-cause fix)."""
+    deps = build_deps()
+    # run_prep yields a ready session with a plan but no answers seeded.
+    session_id = asyncio.run(run_prep(_request(), deps))
+    ctx = asyncio.run(deps.repo.load_context(session_id))
+    assert ctx is not None and ctx.answers == []
+
+    sc = asyncio.run(run_score(ScoreRequest(session_id=session_id), deps))
+
+    # A well-formed empty card is returned (for the direct API caller)...
+    assert isinstance(sc, ScoreCard)
+    assert sc.competency_scores == []
+    assert sc.overall_score == 0.0
+    assert sc.coverage_pct == 0.0
+    assert ScoreCard.model_validate(sc.model_dump()) == sc
+    # ...but the session is flagged no_answers, NOT marked complete.
+    assert deps.repo.get_status(session_id) == "no_answers"
+
+
 def test_run_score_reports_partial_coverage() -> None:
     """Unanswered questions lower coverage_pct and never count as weak."""
     deps = build_deps()

--- a/apps/web/app/report/[id]/page.tsx
+++ b/apps/web/app/report/[id]/page.tsx
@@ -18,6 +18,7 @@ import { CompetencyChart } from "@/components/report/competency-chart";
 import { LanguageReportCard } from "@/components/report/language-report-card";
 import { StrengthsGaps } from "@/components/report/strengths-gaps";
 import { ModelAnswers } from "@/components/report/model-answers";
+import { ScoringPoll } from "@/components/report/scoring-poll";
 import {
   TranscriptSection,
   type TranscriptTurn,
@@ -26,56 +27,74 @@ import {
 // Reads server-only config and calls the agent API per request; never prerender.
 export const dynamic = "force-dynamic";
 
+/**
+ * - `ready`   real scorecard with competency scores → full report.
+ * - `sample`  agent unreachable / unknown session → sample preview.
+ * - `empty`   interview produced no answers (status `no_answers`, or a legacy
+ *             `complete` row with a blank card) → honest empty state, NOT zeros.
+ * - `scoring` interview done but scoring hasn't produced a card yet → poll.
+ * - `error`   session errored (e.g., answers failed to persist) → honest notice.
+ */
+type ReportState = "ready" | "sample" | "empty" | "scoring" | "error";
+
 interface Loaded {
+  state: ReportState;
   scorecard: ScoreCard;
-  /** Parsed interview context for the real row, when present. */
   context: InterviewContext | null;
-  isSample: boolean;
   company: string | null;
   role: string | null;
 }
 
 /**
- * Resolve the scorecard for this session by reading the agent API
+ * Resolve the report state by reading the agent API
  * (`GET /api/session/{id}` → SessionView, which carries `scorecard` + `context`).
- * No Supabase / RLS / auth on the read path, so OSS works without sign-in. On
- * any miss — agent down, not scored yet, bad shape — we fall back to the sample
- * so the report always renders.
+ * The sample preview is used ONLY on a true miss (agent down / unknown session /
+ * shape drift). A real session with no answers resolves to `empty` (never a
+ * misleading all-zeros card), and an in-flight session resolves to `scoring`.
  */
 async function load(id: string): Promise<Loaded> {
-  const fallback: Loaded = {
+  const sample: Loaded = {
+    state: "sample",
     scorecard: SAMPLE_SCORECARD,
     context: null,
-    isSample: true,
     company: SAMPLE_INTERVIEW.company,
     role: SAMPLE_INTERVIEW.role,
   };
 
-  // Read the scorecard through the agent API (which owns persistence) — no
-  // Supabase / RLS / auth on the read path, so OSS works without sign-in. Any
-  // miss (agent down, not scored yet, bad shape) falls back to the sample.
   try {
     const res = await fetch(
       `${serverEnv.agentApiUrl}/api/session/${encodeURIComponent(id)}`,
       { cache: "no-store", signal: AbortSignal.timeout(15_000) },
     );
-    if (!res.ok) return fallback;
+    if (!res.ok) return sample;
 
     const parsed = SessionViewSchema.safeParse(await res.json());
-    if (!parsed.success) return fallback;
+    if (!parsed.success) return sample;
 
     const view = parsed.data;
-    if (!view.scorecard) return fallback;
-
-    return {
-      scorecard: view.scorecard,
+    const base = {
       context: view.context,
-      isSample: false,
       company: view.context?.job.company_name ?? null,
       role: view.context?.job.title ?? null,
     };
+    const answers = view.context?.answers.length ?? 0;
+    const hasScores = (view.scorecard?.competency_scores?.length ?? 0) > 0;
+
+    // Honest empty: no answers were captured. New sessions are flagged
+    // `no_answers`; legacy rows may be `complete` with a blank (score-less) card.
+    if (view.status === "no_answers" || (answers === 0 && !!view.scorecard && !hasScores)) {
+      return { ...base, state: "empty", scorecard: SAMPLE_SCORECARD };
+    }
+    if (view.status === "error" || view.status === "rejected") {
+      return { ...base, state: "error", scorecard: SAMPLE_SCORECARD };
+    }
+    if (view.scorecard && hasScores) {
+      return { ...base, state: "ready", scorecard: view.scorecard };
+    }
+    // Interview not scored yet — poll until a terminal state arrives.
+    return { ...base, state: "scoring", scorecard: SAMPLE_SCORECARD };
   } catch {
-    return fallback;
+    return sample;
   }
 }
 
@@ -118,6 +137,20 @@ function buildTranscript(loaded: Loaded): {
   return { questionText, turns };
 }
 
+/** Shared page chrome for the non-report (status) states. */
+function StatusShell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="mx-auto max-w-[920px] px-6 py-12">
+      <header className="flex items-center justify-between">
+        <Link href="/" className="no-underline">
+          <Eyebrow>DeepInterview</Eyebrow>
+        </Link>
+      </header>
+      <div className="mt-16 flex justify-center">{children}</div>
+    </main>
+  );
+}
+
 export default async function ReportPage({
   params,
 }: {
@@ -128,6 +161,88 @@ export default async function ReportPage({
   // No auth gate: OSS reads the report through the agent API, which needs no
   // sign-in. (Hosted/multi-tenant deployments add auth as a separate layer.)
   const loaded = await load(id);
+
+  // Still scoring: show a calm waiting state and auto-refresh until terminal.
+  if (loaded.state === "scoring") {
+    return (
+      <StatusShell>
+        <ScoringPoll />
+        <Card className="max-w-md text-center">
+          <CardContent className="flex flex-col items-center gap-3 py-10">
+            <span
+              className="h-7 w-7 animate-spin rounded-full border-2 border-accent border-t-transparent"
+              aria-hidden
+            />
+            <h1 className="font-serif text-2xl text-ink">Scoring your interview…</h1>
+            <p className="max-w-sm text-sm leading-relaxed text-muted">
+              Hang tight — we’re analyzing your answers. This page updates
+              automatically the moment your report is ready.
+            </p>
+          </CardContent>
+        </Card>
+      </StatusShell>
+    );
+  }
+
+  // No answers captured: honest empty state instead of an all-zeros report.
+  if (loaded.state === "empty") {
+    return (
+      <StatusShell>
+        <Card className="max-w-md text-center">
+          <CardContent className="flex flex-col items-center gap-4 py-10">
+            <h1 className="font-serif text-2xl text-ink">No answers recorded</h1>
+            <p className="max-w-sm text-sm leading-relaxed text-muted">
+              {loaded.role && loaded.company ? (
+                <>
+                  This {loaded.role} interview at {loaded.company} ended before any
+                  question was answered, so there’s nothing to score yet.{" "}
+                </>
+              ) : (
+                <>
+                  This interview ended before any question was answered, so there’s
+                  nothing to score yet.{" "}
+                </>
+              )}
+              Give it another go — answer out loud and we’ll build your report.
+            </p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link href="/setup" className="no-underline">
+                <Button variant="ink">Practice again</Button>
+              </Link>
+              <Link href="/" className="no-underline">
+                <Button variant="out">Back home</Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </StatusShell>
+    );
+  }
+
+  // Session errored (e.g., answers failed to persist) — be honest, don't fake zeros.
+  if (loaded.state === "error") {
+    return (
+      <StatusShell>
+        <Card className="max-w-md text-center">
+          <CardContent className="flex flex-col items-center gap-4 py-10">
+            <h1 className="font-serif text-2xl text-ink">
+              We couldn’t score this interview
+            </h1>
+            <p className="max-w-sm text-sm leading-relaxed text-muted">
+              Something went wrong saving or scoring this session, so we’re not
+              showing a report rather than show inaccurate results. Please try
+              another run.
+            </p>
+            <Link href="/setup" className="no-underline">
+              <Button variant="ink">Practice again</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </StatusShell>
+    );
+  }
+
+  // ready | sample → the full report.
   const { scorecard } = loaded;
   const { questionText, turns } = buildTranscript(loaded);
 
@@ -138,7 +253,7 @@ export default async function ReportPage({
         <Link href="/" className="no-underline">
           <Eyebrow>DeepInterview</Eyebrow>
         </Link>
-        {loaded.isSample && (
+        {loaded.state === "sample" && (
           <Badge variant="outline">Preview (sample data)</Badge>
         )}
       </header>

--- a/apps/web/components/report/scoring-poll.tsx
+++ b/apps/web/components/report/scoring-poll.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Re-runs the server component (which re-fetches the session view) on an
+ * interval while post-interview scoring is still in flight, so the report
+ * flips to the real result the moment it's ready — without the user refreshing.
+ * Renders nothing; unmounts (and stops polling) once `load()` returns a terminal
+ * state and the page no longer renders this.
+ */
+export function ScoringPoll({ intervalMs = 2500 }: { intervalMs?: number }) {
+  const router = useRouter();
+  useEffect(() => {
+    const t = setInterval(() => router.refresh(), intervalMs);
+    return () => clearInterval(t);
+  }, [router, intervalMs]);
+  return null;
+}

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -11,7 +11,9 @@ import { InterviewContextSchema, ScoreCardSchema } from "@deepinterview/shared";
  */
 export const SessionViewSchema = z.object({
   session_id: z.string(),
-  status: z.enum(["prep", "ready", "rejected", "error", "complete"]),
+  // "no_answers": interview produced no answers; scoring was skipped and no
+  // scorecard written, so the report shows an honest empty state (not zeros).
+  status: z.enum(["prep", "ready", "rejected", "error", "complete", "no_answers"]),
   progress: z.array(z.string()),
   prep_warnings: z.array(z.string()),
   context: InterviewContextSchema.nullable(),


### PR DESCRIPTION
## Problem
A completed interview session with **zero captured answers** was scored into an all‑zeros "complete" scorecard, which reads as mock/placeholder data (observed on a real OpenAI · ML Engineer session). It was real data — just degenerate.

## Root cause
- `post/run_score` had **no empty‑answer guard**: given any context (even `answers: []`) it scored it, persisted a blank card, and marked the session `complete`.
- `worker._on_shutdown` **swallowed `save_context` failures** then triggered scoring anyway → scored the prep‑time (answer‑less) context.
- The web report rendered immediately and only fell back to *sample* on a hard miss.

## Fix
- **agent/post:** `run_score` skips scoring when `ctx.answers` is empty — no blank card persisted; flags the session `no_answers` (not `complete`).
- **agent/worker:** only trigger scoring when `save_context` succeeded (don't score stale data); mark `error` / `no_answers` accordingly; log failures loudly.
- **agent/api + web:** add `no_answers` to the session‑status enum.
- **web/report:** `load()` now resolves `ready / sample / empty / scoring / error`. Sample is used **only** on a true miss; no‑answer sessions (incl. legacy `complete`‑with‑blank‑card rows) show an honest empty state; in‑flight sessions show a "Scoring…" poll (`scoring-poll.tsx`) that auto‑refreshes until terminal.

## Tests
- New regression test `test_run_score_skips_when_no_answers` (empty answers → `no_answers`, not `complete`).
- **Agent suite: 136 passed.** Web `tsc --noEmit`: clean.

Note: legacy rows need no migration — the web detects `answers===0 && blank card` and renders the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)