### PR TITLE
ci: fix pnpm version conflict (ERR_PNPM_BAD_PM_VERSION)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
+        # Version comes from package.json `packageManager` (pnpm@11.5.2).
+        # Pinning it here too makes pnpm/action-setup error with
+        # ERR_PNPM_BAD_PM_VERSION ("Multiple versions of pnpm specified").
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Install pnpm
         if: steps.gate.outputs.enabled == 'true'
+        # Version comes from package.json `packageManager` (pnpm@11.5.2);
+        # pinning here too triggers ERR_PNPM_BAD_PM_VERSION.
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node
         if: steps.gate.outputs.enabled == 'true'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,9 +2,6 @@ packages:
   - "apps/*"
   - "packages/*"
   - "cli"
-allowBuilds:
-  esbuild: set this to true or false
-  sharp: set this to true or false
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
## Problem
Every CI/deploy run fails at **Install pnpm**:
> Error: Multiple versions of pnpm specified — version 11 (action config) + pnpm@11.5.2 (package.json `packageManager`)

`pnpm/action-setup@v4` rejects having both, so nothing downstream (build/typecheck/test) ever runs.

## Fix
Remove the explicit `with: version: 11` from the `pnpm/action-setup@v4` step in both `ci.yml` and `deploy.yml`; let `packageManager: pnpm@11.5.2` in `package.json` drive the version (the action's recommended single-source-of-truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)