### PR TITLE
fix(ci,docker): pnpm 11 allowBuilds + agent worker (livekit) image

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -40,3 +40,12 @@ EXPOSE 8000
 
 # Default = the API service. Override `command:` to run the worker.
 CMD ["uv", "run", "uvicorn", "deepinterview_agent.app:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# ---- worker: base + the `livekit` extra for the live voice loop (WP-5) ------
+# The agent-worker compose service (profile: live) builds THIS target — the base
+# image omits livekit-agents + the STT/TTS/LLM plugin set the worker imports at
+# load time, so running the worker off the base image would ModuleNotFoundError.
+FROM base AS worker
+RUN uv sync --frozen --no-dev --extra livekit || uv sync --no-dev --extra livekit
+# `start` connects to LiveKit and waits for jobs (needs LIVEKIT_*/STT/TTS keys).
+CMD ["uv", "run", "python", "-m", "deepinterview_agent.worker", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     build:
       context: .
       dockerfile: apps/agent/Dockerfile
+      target: base
     command:
       - uv
       - run
@@ -70,6 +71,7 @@ services:
     build:
       context: .
       dockerfile: apps/agent/Dockerfile
+      target: worker
     profiles:
       - live
     command:
@@ -78,6 +80,7 @@ services:
       - python
       - -m
       - deepinterview_agent.worker
+      - start
     env_file:
       - path: .env
         required: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - "apps/*"
   - "packages/*"
   - "cli"
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+# pnpm 11 build-script allowlist (renamed from onlyBuiltDependencies, which pnpm
+# 11 ignores). esbuild + sharp need their native postinstall to run; without
+# approving them here, `pnpm install` fails with ERR_PNPM_IGNORED_BUILDS in
+# CI/Docker (non-interactive).
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Fixes the long-standing CI red **and** completes the Docker setup. Root cause: pnpm 11 renamed the build allowlist `onlyBuiltDependencies` (list, now ignored) → `allowBuilds: {pkg: true}` (map); #14 removed the block as 'malformed' but it just needed `true` values. Set `allowBuilds: {esbuild: true, sharp: true}` → `pnpm install` runs the native postinstalls and exits 0. Also adds a `worker` Dockerfile target (livekit extra) + wires compose targets (agent-api→base, agent-worker→worker) and the worker `start` subcommand. Verified: `docker compose --profile live build` builds all 4 images.