### PR TITLE
fix(docker): agent image must include provider SDK extras

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -31,10 +31,13 @@ WORKDIR /app
 COPY apps/agent/pyproject.toml apps/agent/uv.lock ./
 COPY apps/agent/src ./src
 
-# Base (offline-capable) deps only — no `--extra livekit` / `--extra observability`.
-# The API runs fully on mock providers with zero keys. Enable extras at deploy
-# time for the worker (livekit) or tracing (observability).
-RUN uv sync --frozen --no-dev || uv sync --no-dev
+# Base deps + the lightweight provider SDKs (gemini/openai/supabase/tavily).
+# Without them, setting e.g. SUPABASE_URL or LLM_PROVIDER=gemini in .env makes
+# the API 500 (ModuleNotFoundError) instead of using the configured provider —
+# the image must honor whatever providers the env selects. Still excluded:
+# `livekit` (heavy; worker stage below) and `observability` (opt-in tracing).
+RUN uv sync --frozen --no-dev --extra gemini --extra openai --extra supabase --extra tavily \
+ || uv sync --no-dev --extra gemini --extra openai --extra supabase --extra tavily
 
 EXPOSE 8000
 


### PR DESCRIPTION
Configured providers (Supabase/Gemini/Tavily/OpenAI) crashed the dockerized agent API with `ModuleNotFoundError: No module named 'supabase'` on `POST /api/prep` — the optional SDKs were never installed in the image. The base stage now installs the lightweight extras; `livekit` remains worker-stage-only.

Verified: rebuilt `agent-api`/`agent-worker`, real-key prep runs end-to-end in compose (real Gemini analysis, session persisted to Supabase, 5-question plan, zero fallback warnings); worker registers with LiveKit Cloud.