### PR TITLE
fix(web): waiting status while the interviewer connects (no more dead air)

### DIFF
--- a/apps/web/components/interview/voice-stage.tsx
+++ b/apps/web/components/interview/voice-stage.tsx
@@ -13,6 +13,7 @@
  * which shows the same frame with a static `idle` state and no visualizer.
  */
 
+import * as React from "react";
 import { useVoiceAssistant, BarVisualizer } from "@livekit/components-react";
 import type { AgentState } from "@livekit/components-react";
 import { AvatarStage } from "@/components/avatar/avatar-stage";
@@ -61,6 +62,51 @@ function AccentVisualizer({
   );
 }
 
+/**
+ * Human status line for the wait between joining the room and the
+ * interviewer's FIRST words (worker accepting the job, loading the session
+ * context, synthesizing the greeting — several seconds of otherwise dead air).
+ */
+export function waitingStatusFor(state: AgentState, name: string): string {
+  switch (state) {
+    case "thinking":
+      return "Preparing your first question…";
+    case "listening":
+    case "initializing":
+      return `${name} is getting ready…`;
+    default:
+      // disconnected / connecting / pre-connect buffering / idle / failed —
+      // before the agent participant is fully up.
+      return "Connecting your interviewer…";
+  }
+}
+
+/**
+ * Frosted waiting banner overlaid on the stage until the agent first speaks.
+ * `role="status"` + polite live region so screen readers hear the progress;
+ * the dot pulse is gated on motion-safe.
+ */
+function WaitingOverlay({ label }: { label: string }) {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-20 z-20 flex justify-center px-6">
+      <div
+        role="status"
+        aria-live="polite"
+        className={cn(
+          "inline-flex items-center gap-2.5 rounded-full border border-line",
+          "bg-paper/90 px-4 py-2 backdrop-blur-sm",
+        )}
+      >
+        <span className="relative flex h-2 w-2" aria-hidden>
+          <span className="absolute inline-flex h-full w-full rounded-full bg-accent opacity-60 motion-safe:animate-ping" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-accent" />
+        </span>
+        <span className="text-[13px] text-ink-soft">{label}</span>
+      </div>
+    </div>
+  );
+}
+
 export interface VoiceStageProps {
   persona: Persona;
   className?: string;
@@ -71,10 +117,21 @@ export function VoiceStage({ persona, className }: VoiceStageProps) {
   const { state, audioTrack } = useVoiceAssistant();
   const avatarState = agentStateToAvatarState(state);
 
+  // The waiting banner shows ONLY until the interviewer's first words: once
+  // the agent has spoken, normal mid-interview "thinking" pauses are part of
+  // the conversation rhythm and the avatar/visualizer already convey them.
+  const [hasSpoken, setHasSpoken] = React.useState(false);
+  React.useEffect(() => {
+    if (state === "speaking") setHasSpoken(true);
+  }, [state]);
+
   return (
     <div className={cn("relative", className)}>
       <AvatarStage persona={persona} state={avatarState} />
       {audioTrack && <AccentVisualizer state={state} track={audioTrack} />}
+      {!hasSpoken && (
+        <WaitingOverlay label={waitingStatusFor(state, persona.name)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Joining the interview had several seconds of silence — the worker accepts the job, loads the session context, and synthesizes the greeting — with the UI giving zero feedback.

The stage now overlays a status banner derived from `useVoiceAssistant().state`:

- connecting/disconnected → **Connecting your interviewer…**
- initializing/listening → **<persona> is getting ready…**
- thinking → **Preparing your first question…**

It disappears permanently the moment the interviewer first speaks (mid-interview thinking pauses are conversation rhythm — the avatar + visualizer already convey those). `role=status` + polite `aria-live` for screen readers; the pulse dot is `motion-safe`-gated.

Verified: typecheck, lint, and `next build` pass.