### PR TITLE
fix(live): BVC noise cancellation opt-in — init failure silenced all input audio

### DIFF
--- a/apps/agent/src/deepinterview_agent/core/config.py
+++ b/apps/agent/src/deepinterview_agent/core/config.py
@@ -104,6 +104,14 @@ class Settings(BaseSettings):
     enable_score_verifier: bool = False
     score_verifier_timeout_sec: float = 60.0
 
+    # --- live: BVC noise cancellation (opt-in) --------------------------------
+    # OFF by default: the BVC native filter failed to initialize inside the
+    # slim arm64 container ("failed to initialize the audio filter") and took
+    # the whole input audio stream down with it — the agent heard nothing.
+    # Enable with ENABLE_BVC=true only on hosts where it's verified to load.
+    # Noise robustness without it: semantic turn detector + min_words gate.
+    enable_bvc: bool = False
+
     # --- live cost / duration guard (Golden Rule #5: cap voice in code) -------
     # Hard ceilings enforced by the worker's SessionGuard so a live room can
     # never run unbounded (a stalled/looping LLM would otherwise burn voice

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -189,15 +189,18 @@ def build_turn_handling() -> dict:
 
 
 def build_room_options(settings):  # noqa: ANN001, ANN201
-    """Room I/O options: BVC noise cancellation when running on LiveKit Cloud.
+    """Room I/O options: BVC noise cancellation, strictly opt-in (ENABLE_BVC).
 
-    BVC strips background noise BEFORE VAD/STT see it — the root fix for noise
-    holding the turn open. It is a LiveKit Cloud feature, so it is enabled only
-    for *.livekit.cloud URLs; self-hosted deployments get plain mic audio.
-    Returns None (SDK defaults) when unavailable.
+    BVC strips background noise BEFORE VAD/STT see it, but its native filter
+    failed to initialize in the slim arm64 container and the input audio
+    stream it was attached to delivered NO frames — the agent heard nothing
+    for the whole session. So it is off unless ENABLE_BVC=true AND the
+    deployment is LiveKit Cloud (BVC is a Cloud feature). Noise robustness
+    otherwise comes from the semantic turn detector + min_words gate.
+    Returns None (SDK defaults) when not enabled.
     """
     url = settings.livekit_url or ""
-    if "livekit.cloud" not in url:
+    if not settings.enable_bvc or "livekit.cloud" not in url:
         return None
     try:
         from livekit.agents.voice.room_io import AudioInputOptions, RoomOptions  # noqa: PLC0415


### PR DESCRIPTION
In the dockerized worker (slim arm64), BVC's native filter failed to init (`failed to initialize the audio filter`) and the input AudioStream it was attached to delivered zero frames — the agent played its greeting and then heard nothing: no STT, no VAD, no turn detection for the whole session (director stuck at cursor 0/5).

Fix: BVC is now strictly opt-in via `ENABLE_BVC=true` (and still LiveKit-Cloud-gated). The default path never attaches an audio filter, so input audio can't be taken down by it. The noise-robustness fixes that matter — semantic end-of-turn (MultilingualModel) and the 3-word interruption gate — remain active.

Verified: 139 tests pass, ruff clean, gating smoke-tested (default → None; opt-in on cloud → RoomOptions with BVC). Worker image rebuilt and re-registered with LiveKit Cloud.