### PR TITLE
fix(live): Vietnamese turn smoothness — per-language turn handling + cache-stable image layers

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -27,15 +27,35 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
-# Copy project metadata first for layer caching, then sources.
+# Dependency layers FIRST (lockfiles only, --no-install-project), source LAST:
+# deps and the baked ML models stay cached across code edits — previously any
+# one-line src change re-downloaded the turn-detector weights (minutes).
 COPY apps/agent/pyproject.toml apps/agent/uv.lock ./
-COPY apps/agent/src ./src
 
 # Base deps + the lightweight provider SDKs (gemini/openai/supabase/tavily).
 # Without them, setting e.g. SUPABASE_URL or LLM_PROVIDER=gemini in .env makes
 # the API 500 (ModuleNotFoundError) instead of using the configured provider —
 # the image must honor whatever providers the env selects. Still excluded:
-# `livekit` (heavy; worker stage below) and `observability` (opt-in tracing).
+# `livekit` (heavy; worker stages below) and `observability` (opt-in tracing).
+RUN uv sync --frozen --no-dev --no-install-project --extra gemini --extra openai --extra supabase --extra tavily \
+ || uv sync --no-dev --no-install-project --extra gemini --extra openai --extra supabase --extra tavily
+
+# ---- worker-deps: + the `livekit` extra and baked model weights (no src) ----
+# Branches BEFORE the source copy so the heavy plugin install and the
+# turn-detector/Silero model downloads are cache-stable across code changes.
+FROM base AS worker-deps
+RUN uv sync --frozen --no-dev --no-install-project --extra livekit --extra gemini --extra openai --extra supabase --extra tavily \
+ || uv sync --no-dev --no-install-project --extra livekit --extra gemini --extra openai --extra supabase --extra tavily
+# Bake the semantic turn-detector model weights (and Silero VAD) into the
+# image: importing each plugin registers it, download_files() fetches its
+# model. Without this the FIRST live session stalls on a runtime download.
+RUN .venv/bin/python -c "import livekit.plugins.silero, livekit.plugins.turn_detector; \
+from livekit.agents.plugin import Plugin; \
+[p.download_files() for p in Plugin.registered_plugins]"
+
+# ---- api: deps + source (compose `agent-api` builds target: api) ------------
+FROM base AS api
+COPY apps/agent/src ./src
 RUN uv sync --frozen --no-dev --extra gemini --extra openai --extra supabase --extra tavily \
  || uv sync --no-dev --extra gemini --extra openai --extra supabase --extra tavily
 
@@ -44,17 +64,13 @@ EXPOSE 8000
 # Default = the API service. Override `command:` to run the worker.
 CMD ["uv", "run", "uvicorn", "deepinterview_agent.app:app", "--host", "0.0.0.0", "--port", "8000"]
 
-# ---- worker: base + the `livekit` extra for the live voice loop (WP-5) ------
-# The agent-worker compose service (profile: live) builds THIS target — the base
-# image omits livekit-agents + the STT/TTS/LLM plugin set the worker imports at
-# load time, so running the worker off the base image would ModuleNotFoundError.
-FROM base AS worker
-RUN uv sync --frozen --no-dev --extra livekit || uv sync --no-dev --extra livekit
-# Bake the semantic turn-detector model weights (and Silero VAD) into the
-# image: importing each plugin registers it, download_files() fetches its
-# model. Without this the FIRST live session stalls on a runtime download.
-RUN uv run python -c "import livekit.plugins.silero, livekit.plugins.turn_detector; \
-from livekit.agents.plugin import Plugin; \
-[p.download_files() for p in Plugin.registered_plugins]"
+# ---- worker: worker-deps + source (compose `agent-worker`, profile: live) ---
+# The api image omits livekit-agents + the STT/TTS/LLM plugin set the worker
+# imports at load time, so running the worker off the api image would
+# ModuleNotFoundError.
+FROM worker-deps AS worker
+COPY apps/agent/src ./src
+RUN uv sync --frozen --no-dev --extra livekit --extra gemini --extra openai --extra supabase --extra tavily \
+ || uv sync --no-dev --extra livekit --extra gemini --extra openai --extra supabase --extra tavily
 # `start` connects to LiveKit and waits for jobs (needs LIVEKIT_*/STT/TTS keys).
 CMD ["uv", "run", "python", "-m", "deepinterview_agent.worker", "start"]

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -206,28 +206,42 @@ def build_tts(settings, language="en"):  # noqa: ANN001, ANN201
     return cartesia.TTS(language=lang)
 
 
-def build_turn_handling() -> dict:
+# Languages the LiveKit multilingual end-of-turn model can judge semantically.
+# Vietnamese is NOT among them — for unsupported languages the session falls
+# back to silence-based endpointing, where the default 0.5s cutoff chops
+# natural mid-sentence pauses into separate turns (confirmed in vi testing:
+# fragmented one-clause "answers" with the agent jumping in between).
+_EOU_MODEL_LANGS = frozenset(
+    {"en", "es", "fr", "de", "it", "pt", "nl", "zh", "ja", "ko", "id", "tr", "ru"}
+)
+
+
+def build_turn_handling(language: str = "en") -> dict:
     """Turn-handling config shared by the interview and coach sessions.
 
-    Two noisy-environment defenses on top of the SDK defaults:
+    Defenses on top of the SDK defaults:
 
     * ``min_words: 3`` — an interruption only registers once the candidate has
       actually SAID a few transcribed words. The default (0) lets raw VAD
       energy interrupt, so a door slam or background chatter cuts the
       interviewer off mid-sentence.
-    * Semantic end-of-turn (``MultilingualModel``) — "is the candidate done?"
-      is judged from the transcript instead of waiting for clean silence,
-      which ambient noise can otherwise hold open indefinitely (the agent
-      looks stuck in "listening"). Falls back to default VAD/STT endpointing
-      when the plugin or its model files are unavailable.
+    * Semantic end-of-turn (``MultilingualModel``) for languages it supports —
+      "is the candidate done?" is judged from the transcript instead of
+      waiting for clean silence.
+    * For languages the model can't judge (e.g. Vietnamese): stretch the
+      silence endpointing window instead (1.2s min / 4s max) so natural
+      pauses don't end the candidate's turn mid-sentence.
     """
     handling: dict = {"interruption": {"min_words": 3}}
-    try:
-        from livekit.plugins.turn_detector.multilingual import MultilingualModel  # noqa: PLC0415
+    if language in _EOU_MODEL_LANGS:
+        try:
+            from livekit.plugins.turn_detector.multilingual import MultilingualModel  # noqa: PLC0415
 
-        handling["turn_detection"] = MultilingualModel()
-    except Exception:  # noqa: BLE001 - optional model; endpointing still works without it
-        log.warning("build_turn_handling: turn-detector unavailable; using VAD/STT endpointing")
+            handling["turn_detection"] = MultilingualModel()
+            return handling
+        except Exception:  # noqa: BLE001 - optional model; fall through to endpointing
+            log.warning("build_turn_handling: turn-detector unavailable; using endpointing")
+    handling["endpointing"] = {"min_delay": 1.2, "max_delay": 4.0}
     return handling
 
 
@@ -350,7 +364,7 @@ async def entrypoint(ctx: JobContext) -> None:
         # Lean live loop: preemptive generation is on by default in 1.5.x;
         # turn_handling adds the noisy-environment defenses (semantic
         # end-of-turn + word-gated interruptions — see build_turn_handling).
-        turn_handling=build_turn_handling(),
+        turn_handling=build_turn_handling(lang_mode.primary),
     )
 
     # Persisted transcript = real committed turns (STT + agent speech), not

--- a/apps/agent/src/deepinterview_agent/worker_coach.py
+++ b/apps/agent/src/deepinterview_agent/worker_coach.py
@@ -92,7 +92,7 @@ async def entrypoint(ctx: JobContext) -> None:
         # Same noisy-environment defenses as the interview worker (semantic
         # end-of-turn + word-gated interruptions); preemptive generation is on
         # by default in 1.5.x.
-        turn_handling=build_turn_handling(),
+        turn_handling=build_turn_handling(primary),
     )
 
     # Capture the real coach conversation (CoachAgent has no tools, so nothing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     build:
       context: .
       dockerfile: apps/agent/Dockerfile
-      target: base
+      target: api
     command:
       - uv
       - run


### PR DESCRIPTION
Vietnamese transcription worked (PR #26) but conversations were rough: the multilingual EOU model does NOT support vi, so sessions fell back to silence endpointing at the 0.5s default — natural mid-sentence pauses chopped answers into one-clause fragments with the agent jumping in (confirmed live; transcript showed fragmented YOU turns).

**Changes**
- `build_turn_handling(language)`: languages the EOU model supports keep semantic turn detection; unsupported ones (vi, …) **skip the model** and stretch silence endpointing to **1.2s min / 4s max** so pauses don't end the turn.
- **Dockerfile layer reorder**: deps + baked model weights now build from lockfiles only (`--no-install-project`) before the source copy — a one-line code change previously re-downloaded the turn-detector weights (minutes); now it rebuilds in seconds. `api`/`worker` are separate targets branching from shared dep stages (compose `agent-api` → `target: api`).

**Verified**: compose config OK; 139 agent tests pass; ruff clean; `build_turn_handling('vi')` → endpointing {1.2, 4.0} with no detector, `'en'` keeps the model.