### PR TITLE
fix(live): recover unsaved answers at shutdown so real interviews always get a report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ site/
 
 # Local agent instructions — never publish
 CLAUDE.md
+
+# Supabase CLI local state (project ref, pooler URL)
+supabase/.temp/

--- a/apps/agent/src/deepinterview_agent/live/state.py
+++ b/apps/agent/src/deepinterview_agent/live/state.py
@@ -37,6 +37,13 @@ _RICH_WORDS = 80
 # there is a higher rung left to climb to.
 _MAX_DIFFICULTY = 5
 
+# Minimum substance (word count) for a transcript-recovered answer — reuses the
+# _THIN_WORDS difficulty threshold. Below it, a question's user speech is small
+# talk or fragments (the reply to the greeting, "yes", "thanks, goodbye"), not
+# an answer: recovering it would fire the full LLM scoring pipeline on junk and
+# produce a misleading near-zero report instead of the honest no_answers state.
+_MIN_RECOVERED_WORDS = _THIN_WORDS
+
 
 @dataclass
 class InterviewUserdata:
@@ -124,8 +131,74 @@ def next_section(ud: InterviewUserdata) -> PlannedQuestion | None:
 
 
 def add_turn(ud: InterviewUserdata, role: str, text: str) -> None:
-    """Append a turn to the flat running transcript log."""
-    ud.transcript.append({"role": role, "text": text})
+    """Append a turn to the flat running transcript log.
+
+    Each turn is tagged with the question active at the time it was spoken so
+    :func:`reconstruct_answers` can recover unsaved answers on shutdown. An
+    empty ``question_id`` means the cursor was already past the planned end.
+    """
+    q = current_question(ud)
+    ud.transcript.append(
+        {"role": role, "text": text, "question_id": q.id if q is not None else ""}
+    )
+
+
+def reconstruct_answers(ud: InterviewUserdata) -> int:
+    """Recover unsaved answers from the verbatim transcript (shutdown fallback).
+
+    ``ctx.answers`` is normally filled by the model calling the ``save_answer``
+    tool — but the model can forget, and the candidate can hang up mid-question
+    before the tool ever fires. Both used to silently drop everything the
+    candidate said, flipping the session to ``no_answers`` ("no report") even
+    though the transcript held real answers.
+
+    For every question id that has user speech in the transcript but no
+    substantive saved answer, join that question's user turns into a new
+    :class:`AnswerRecord` (verbatim STT text, blank timestamps). Saved answers
+    are never touched. Returns the number of records added.
+
+    Guards:
+
+    * Substance gate: a question's joined speech must reach
+      ``_MIN_RECOVERED_WORDS`` words. Greeting small talk and one-word
+      acknowledgements stay unrecovered, so a contentless call keeps its
+      honest ``no_answers`` state instead of getting a junk scorecard.
+    * "Saved" matches the scorers' last-wins indexing (``{a.question_id: a}``):
+      a question only counts as saved if its LAST record has substance, so a
+      trailing ``save_answer("")`` cannot simultaneously void a question and
+      block its recovery.
+
+    Known residual: a candidate continuing their previous answer after the
+    cursor has advanced is tagged with the new question's id (cross-question
+    contamination). livekit-agents 1.5.x commits the user turn before tool
+    execution, so this only occurs on genuinely overlapping speech.
+    """
+    last_by_qid: dict[str, AnswerRecord] = {}
+    for a in ud.ctx.answers:
+        last_by_qid[a.question_id] = a
+    saved = {qid for qid, a in last_by_qid.items() if (a.transcript or "").strip()}
+    spoken: dict[str, list[str]] = {}
+    for turn in ud.transcript:
+        qid = turn.get("question_id") or ""
+        text = (turn.get("text") or "").strip()
+        if turn.get("role") != "user" or not qid or not text or qid in saved:
+            continue
+        spoken.setdefault(qid, []).append(text)
+    added = 0
+    for qid, texts in spoken.items():
+        joined = " ".join(texts)
+        if len(joined.split()) < _MIN_RECOVERED_WORDS:
+            continue
+        ud.ctx.answers.append(
+            AnswerRecord(
+                question_id=qid,
+                transcript=joined,
+                started_at="",
+                ended_at="",
+            )
+        )
+        added += 1
+    return added
 
 
 # --- adaptive difficulty (pure, livekit-free, deterministic) -----------------

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -82,15 +82,22 @@ def wire_audio_path_logging(ctx: JobContext, session) -> None:  # noqa: ANN001
                  getattr(ev, "is_final", "?"), len(getattr(ev, "transcript", "") or ""))
 
 
-def wire_transcript_capture(session, userdata: InterviewUserdata) -> None:  # noqa: ANN001
+def wire_transcript_capture(
+    session, userdata: InterviewUserdata, *, tag_questions: bool = True  # noqa: ANN001
+) -> None:
     """Capture every committed conversation turn into the flat transcript log.
 
     ``conversation_item_added`` fires for both the candidate's real STT
     transcript and the agent's actually-spoken replies, so the persisted
     transcript reflects what was said — it no longer depends on the LLM
     remembering to call ``save_answer``, and an abrupt disconnect keeps every
-    turn committed so far. (Answers for SCORING still come from ``save_answer``
-    -> ``ctx.answers``; this log is the verbatim record.)
+    turn committed so far. Answers for scoring come from ``save_answer`` ->
+    ``ctx.answers``, with ``state.reconstruct_answers`` recovering any unsaved
+    ones from this log at shutdown.
+
+    ``tag_questions=False`` skips the per-turn question-id tag for sessions
+    that reuse an interview context but are not answering its plan (the study
+    coach) — otherwise coach chat would carry stale interview question ids.
     """
 
     @session.on("conversation_item_added")
@@ -99,7 +106,10 @@ def wire_transcript_capture(session, userdata: InterviewUserdata) -> None:  # no
         role = getattr(item, "role", None)
         text = getattr(item, "text_content", None)
         if role in ("user", "assistant") and text:
-            state.add_turn(userdata, role, text)
+            if tag_questions:
+                state.add_turn(userdata, role, text)
+            else:
+                userdata.transcript.append({"role": role, "text": text})
 
 
 # --- component factories -----------------------------------------------------
@@ -493,6 +503,18 @@ async def entrypoint(ctx: JobContext) -> None:
             log.info("worker: session %s usage: %s", session_id, summary)
         except Exception:  # noqa: BLE001
             log.exception("worker: usage summary failed for %s", session_id)
+
+        # Recover answers the save_answer tool never committed (model forgot to
+        # call it, or the candidate hung up mid-question) from the verbatim
+        # transcript — otherwise real answers are dropped and the session lands
+        # on "no_answers" with no report.
+        recovered = state.reconstruct_answers(userdata)
+        if recovered:
+            log.info(
+                "worker: session %s recovered %d answer(s) from transcript",
+                session_id,
+                recovered,
+            )
 
         # An answer only counts if it has a non-empty transcript — a bare
         # save_answer("") must not flip the session into the scoring path.

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -119,6 +119,43 @@ def _stt_lang(language: str, mixed: bool) -> str:
     return "multi" if mixed else _STT_LANG.get(language, "en")
 
 
+def _deepgram_stt(lang: str, model: str, api_key=None):  # noqa: ANN001, ANN201
+    """Return a configured deepgram.STT instance with tuned params for each language tier.
+
+    nova-3 (en/multi):
+      - endpointing_ms=25: aggressive VAD is fine; semantic EOU model handles turns.
+      - numerals=True: gated to this tier to keep the nova-2 flag set minimal —
+        bad flag combos on non-English streams fail SILENTLY with zero
+        transcripts (see the nova-3+vi note in build_stt), and smart_format
+        already covers number formatting where supported.
+      - keyterm: not set here (per-session domain terms could be injected later).
+
+    nova-2 (all other languages incl. vi):
+      - endpointing_ms=300: Deepgram's own server-side silence window; 25ms fires
+        too eagerly for languages with more within-utterance pauses (e.g. Vietnamese),
+        flooding us with fragmented partials before our LiveKit 1.2s window acts.
+
+    smart_format=True applies to BOTH tiers (broadly language-supported:
+    number/date formatting).
+    """
+    from livekit.plugins import deepgram  # noqa: PLC0415
+
+    is_nova3 = model == "nova-3"
+    kwargs = dict(
+        language=lang,
+        model=model,
+        punctuate=True,
+        filler_words=True,
+        vad_events=True,
+        numerals=is_nova3,
+        smart_format=True,
+        endpointing_ms=25 if is_nova3 else 300,
+    )
+    if api_key is not None:
+        kwargs["api_key"] = api_key
+    return deepgram.STT(**kwargs)
+
+
 def build_stt(settings, language="en", mixed=False):  # noqa: ANN001, ANN201 - livekit plugin types optional
     lang = _stt_lang(language, mixed)
     # CONFIRMED in live testing (2026-06-10): nova-3 + language=vi returns NO
@@ -129,17 +166,13 @@ def build_stt(settings, language="en", mixed=False):  # noqa: ANN001, ANN201 - l
     model = "nova-3" if lang in ("en", "multi") else "nova-2"
     provider = settings.stt_provider
     if provider == "deepgram" and settings.deepgram_api_key:
-        from livekit.plugins import deepgram  # noqa: PLC0415
-
-        return deepgram.STT(api_key=settings.deepgram_api_key, language=lang, model=model)
+        return _deepgram_stt(lang, model, api_key=settings.deepgram_api_key)
     if provider == "soniox" and settings.soniox_api_key:
         from livekit.plugins import soniox  # noqa: PLC0415
 
         return soniox.STT(api_key=settings.soniox_api_key)
     log.warning("build_stt: no configured STT provider/key; using Deepgram default")
-    from livekit.plugins import deepgram  # noqa: PLC0415
-
-    return deepgram.STT(language=lang, model=model)
+    return _deepgram_stt(lang, model)
 
 
 def build_llm(settings):  # noqa: ANN001, ANN201

--- a/apps/agent/src/deepinterview_agent/worker_coach.py
+++ b/apps/agent/src/deepinterview_agent/worker_coach.py
@@ -96,8 +96,10 @@ async def entrypoint(ctx: JobContext) -> None:
     )
 
     # Capture the real coach conversation (CoachAgent has no tools, so nothing
-    # else ever fills the transcript log).
-    wire_transcript_capture(session, userdata)
+    # else ever fills the transcript log). tag_questions=False: the coach chat
+    # is not answering the interview plan, so turns must not carry its
+    # (possibly mid-plan) question ids.
+    wire_transcript_capture(session, userdata, tag_questions=False)
 
     # Same hard cost/duration backstop as the interview (Golden Rule #5): a
     # coaching chat is also a metered voice session and must never run unbounded.

--- a/apps/agent/tests/test_live.py
+++ b/apps/agent/tests/test_live.py
@@ -133,14 +133,284 @@ def test_next_section_at_end_returns_none() -> None:
 
 def test_add_turn_and_compact_summary() -> None:
     ud = _userdata()
+    q1 = state.current_question(ud)
+    assert q1 is not None
     state.add_turn(ud, "assistant", "Tell me about a hard bug you fixed.")
     state.add_turn(ud, "user", "I traced a race condition in our ledger writer.")
     assert ud.transcript == [
-        {"role": "assistant", "text": "Tell me about a hard bug you fixed."},
-        {"role": "user", "text": "I traced a race condition in our ledger writer."},
+        {
+            "role": "assistant",
+            "text": "Tell me about a hard bug you fixed.",
+            "question_id": q1.id,
+        },
+        {
+            "role": "user",
+            "text": "I traced a race condition in our ledger writer.",
+            "question_id": q1.id,
+        },
     ]
 
     summary = state.compact_summary(ud)
     assert ud.ctx.candidate.name in summary
     assert ud.ctx.job.title in summary
     assert ud.ctx.candidate.summary_120w in summary
+
+
+def test_add_turn_past_end_has_empty_question_id() -> None:
+    ud = _userdata()
+    ud.ctx.cursor = len(ud.ctx.plan.questions)
+    state.add_turn(ud, "user", "Thanks, goodbye!")
+    assert ud.transcript[-1]["question_id"] == ""
+
+
+def test_reconstruct_answers_recovers_unsaved_user_turns() -> None:
+    """A hang-up before save_answer must not drop what the candidate said."""
+    ud = _userdata_two_sections()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+    state.add_turn(ud, "assistant", "Tell me about a hard bug you fixed.")
+    state.add_turn(ud, "user", "I traced a race condition in our ledger writer")
+    state.add_turn(ud, "user", "by bisecting the commit history and adding a regression test.")
+    assert ud.ctx.answers == []
+
+    added = state.reconstruct_answers(ud)
+
+    assert added == 1
+    record = ud.ctx.answers[-1]
+    assert record.question_id == q1.id
+    assert record.transcript == (
+        "I traced a race condition in our ledger writer "
+        "by bisecting the commit history and adding a regression test."
+    )
+
+
+def test_reconstruct_answers_skips_saved_questions_and_is_idempotent() -> None:
+    ud = _userdata_two_sections()
+    state.add_turn(
+        ud, "user", "raw stt text for question one with enough words to clear the substance gate"
+    )
+    state.save_answer(
+        ud,
+        transcript="The model's curated answer for question one.",
+        started_at="",
+        ended_at="",
+    )
+    state.advance(ud)  # -> q_behavioral
+    state.add_turn(
+        ud, "user", "an answer the model never saved about leading the on-call rotation overhaul"
+    )
+
+    added = state.reconstruct_answers(ud)
+
+    # Only the unsaved second question is recovered; the saved one is untouched.
+    assert added == 1
+    assert len(ud.ctx.answers) == 2
+    assert ud.ctx.answers[0].transcript.startswith("The model's curated")
+    assert ud.ctx.answers[1].question_id == "q_behavioral"
+    assert ud.ctx.answers[1].transcript == (
+        "an answer the model never saved about leading the on-call rotation overhaul"
+    )
+
+    # Running again adds nothing.
+    assert state.reconstruct_answers(ud) == 0
+    assert len(ud.ctx.answers) == 2
+
+
+def test_reconstruct_answers_ignores_blank_and_assistant_turns() -> None:
+    ud = _userdata()
+    state.add_turn(ud, "assistant", "Tell me about a hard bug you fixed.")
+    state.add_turn(ud, "user", "   ")
+    assert state.reconstruct_answers(ud) == 0
+    assert ud.ctx.answers == []
+
+
+# --- recovery edge cases (regression pins for the no_answers production bug) --
+
+
+def test_reconstruct_answers_turns_follow_cursor_across_advances() -> None:
+    """Turns are bucketed by the question active when spoken, not replayed flat.
+
+    Speech before ``advance`` belongs to Q1; speech after belongs to Q2. Recovery
+    must yield one record per question, each containing ONLY its own turns.
+    """
+    ud = _userdata_two_sections()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+    state.add_turn(ud, "user", "first part of answer one about sharding the ledger")
+    state.add_turn(ud, "user", "second part of answer one covering the rollout and metrics")
+
+    state.advance(ud)  # get_next_question semantics: cursor -> q_behavioral
+    q2 = state.current_question(ud)
+    assert q2 is not None
+    assert q2.id != q1.id
+    state.add_turn(
+        ud, "user", "the whole of answer two describing how I mentored two junior engineers"
+    )
+
+    added = state.reconstruct_answers(ud)
+
+    assert added == 2
+    by_id = {a.question_id: a for a in ud.ctx.answers}
+    assert set(by_id) == {q1.id, q2.id}
+    # Each record joins only its own turns, in spoken order — no cross-bleed.
+    assert by_id[q1.id].transcript == (
+        "first part of answer one about sharding the ledger "
+        "second part of answer one covering the rollout and metrics"
+    )
+    assert by_id[q2.id].transcript == (
+        "the whole of answer two describing how I mentored two junior engineers"
+    )
+
+
+def test_reconstruct_answers_joins_multi_fragment_answer_in_spoken_order() -> None:
+    """Three STT fragments for one question join with single spaces, in order."""
+    ud = _userdata()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+    # Fragments carry stray whitespace the way streaming STT finals often do.
+    state.add_turn(ud, "user", "  I shipped the ledger")
+    state.add_turn(ud, "user", "then I profiled it  ")
+    state.add_turn(ud, "user", "and fixed the hot path")
+
+    assert state.reconstruct_answers(ud) == 1
+    record = ud.ctx.answers[-1]
+    assert record.question_id == q1.id
+    assert record.transcript == "I shipped the ledger then I profiled it and fixed the hot path"
+
+
+def test_reconstruct_answers_preserves_existing_answer_order_for_last_wins() -> None:
+    """Recovered records append AFTER saved ones, so ``{a.question_id: a}``
+    last-wins indexing (evaluator/report/verifier) can never replace a curated
+    answer with a verbatim STT one for the same question id.
+    """
+    ud = _userdata_two_sections()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+    # Q1: raw speech AND a curated save_answer from the model. The speech
+    # clears the substance gate, so ONLY the qid-in-saved guard prevents a
+    # second record for Q1.
+    state.add_turn(
+        ud, "user", "raw stt text the model rewrote about debugging the sharded ledger consistency bug"
+    )
+    state.save_answer(
+        ud,
+        transcript="The model's curated answer for question one.",
+        started_at="2026-06-08T09:00:00Z",
+        ended_at="2026-06-08T09:01:30Z",
+    )
+    state.advance(ud)  # -> q_behavioral
+    state.add_turn(
+        ud, "user", "speech for question two that was never saved about migrating the billing service"
+    )
+
+    added = state.reconstruct_answers(ud)
+
+    # qid-in-saved guard, asserted directly: speech for an already-saved Q never
+    # creates a second record for that id.
+    assert added == 1
+    q1_records = [a for a in ud.ctx.answers if a.question_id == q1.id]
+    assert len(q1_records) == 1
+    assert q1_records[0].transcript == "The model's curated answer for question one."
+
+    # Ordering: every recovered record sits after every saved record, so the
+    # last-wins index resolves each id to the curated answer when one exists.
+    assert [a.question_id for a in ud.ctx.answers] == [q1.id, "q_behavioral"]
+    by_id = {a.question_id: a for a in ud.ctx.answers}
+    assert by_id[q1.id].transcript.startswith("The model's curated")
+    assert by_id["q_behavioral"].transcript == (
+        "speech for question two that was never saved about migrating the billing service"
+    )
+
+
+def test_evaluate_difficulty_sees_recovered_answers() -> None:
+    """Recovery feeds adaptive difficulty: a recovered answer counts in
+    ``answered_in_section`` exactly like a tool-saved one. (A recovered answer
+    always carries at least ``_MIN_RECOVERED_WORDS`` words — the substance gate
+    — so it can never read as "thin" / flip the heuristic to "easier".)
+    """
+    ud = _userdata()
+    section = state.current_section(ud)
+    assert section is not None and section != "wrap"
+
+    # Before recovery there is no evidence in the section.
+    before = state.evaluate_difficulty(ud)
+    assert before.answered_in_section == 0
+    assert before.recommendation == "advance"
+
+    # A moderate (>= _MIN_RECOVERED_WORDS, <= _RICH_WORDS) unsaved answer.
+    state.add_turn(
+        ud, "user", "I used Python with asyncio to rebuild the ingestion worker around batching."
+    )
+    assert state.reconstruct_answers(ud) == 1
+
+    after = state.evaluate_difficulty(ud)
+    assert after.answered_in_section == 1
+    # Moderate substance in a covered section -> stay on plan.
+    assert after.recommendation == "advance"
+
+
+def test_reconstruct_answers_substance_gate_drops_small_talk() -> None:
+    """Sub-threshold speech is small talk, not an answer (confirmed-review pin).
+
+    The greeting reply ("Hi, nice to meet you!") is tagged with Q1's id because
+    ``on_enter`` greets and asks Q1 in one breath. Recovering it would fire the
+    full LLM scoring pipeline on junk and replace the honest ``no_answers``
+    empty state with a misleading near-zero report.
+    """
+    ud = _userdata()
+    state.add_turn(ud, "assistant", "Hi! I'll be running your mock interview today.")
+    state.add_turn(ud, "user", "Hi, nice to meet you, I'm ready!")
+
+    assert state.reconstruct_answers(ud) == 0
+    assert ud.ctx.answers == []
+
+
+def test_reconstruct_answers_substance_gate_boundary() -> None:
+    """The gate is exact: 11 joined words drop, 12 recover — and fragments
+    accumulate toward the threshold across turns for the same question.
+    """
+    eleven = "one two three four five six seven eight nine ten eleven"
+    ud = _userdata()
+    state.add_turn(ud, "user", eleven)
+    assert state.reconstruct_answers(ud) == 0
+    assert ud.ctx.answers == []
+
+    # A later fragment for the same question pushes it over the threshold.
+    state.add_turn(ud, "user", "twelve")
+    assert state.reconstruct_answers(ud) == 1
+    assert ud.ctx.answers[-1].transcript == f"{eleven} twelve"
+
+
+def test_trailing_empty_save_answer_does_not_block_recovery() -> None:
+    """The saved-guard mirrors the scorers' last-wins indexing: a trailing
+    ``save_answer("")`` voids the question for scoring, so real speech for it
+    must still be recovered — and the recovered record, appended last, is what
+    ``{a.question_id: a}`` resolves to.
+    """
+    ud = _userdata()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+    state.add_turn(
+        ud, "user", "I rebuilt the payments retry queue and cut duplicate charges to zero."
+    )
+    state.save_answer(ud, transcript="A curated answer.", started_at="", ended_at="")
+    # The model fumbles a second tool call: the trailing record voids Q1 under
+    # last-wins indexing.
+    state.save_answer(ud, transcript="", started_at="", ended_at="")
+
+    assert state.reconstruct_answers(ud) == 1
+    by_id = {a.question_id: a for a in ud.ctx.answers}
+    assert by_id[q1.id].transcript.startswith("I rebuilt the payments retry queue")
+
+
+def test_reconstruct_answers_never_recovers_wrap_phase_speech() -> None:
+    """User speech after the last planned question (question_id == "") is
+    goodbye chatter, not an answer — it must never become an AnswerRecord.
+    """
+    ud = _userdata()
+    ud.ctx.cursor = len(ud.ctx.plan.questions)  # past the end
+    state.add_turn(ud, "user", "Thanks, this was a great conversation, goodbye!")
+    assert ud.transcript[-1]["question_id"] == ""
+
+    assert state.reconstruct_answers(ud) == 0
+    assert ud.ctx.answers == []

--- a/apps/agent/tests/test_report_regression.py
+++ b/apps/agent/tests/test_report_regression.py
@@ -1,0 +1,381 @@
+"""End-to-end regression suite for the report feature at the API level.
+
+The offline twin of the production flow ``prep -> live -> live-result -> score
+-> session view``: a session is prepped with the deterministic adapters
+(MockLLM / MockSearch / MemoryRepository — no keys, no network), the live
+interview is simulated through the pure ``live.state`` machine (the worker's
+livekit wrapper is NOT importable in the test venv), and the worker's shutdown
+write-back is replayed verbatim over the FastAPI app: ``state.reconstruct_answers``
+first (exactly as ``worker._on_shutdown`` does, BEFORE computing ``has_answers``),
+then ``POST /api/session/{id}/live-result``, then ``POST /api/score``, then
+``GET /api/session/{id}``.
+
+The production bug pinned here: sessions with real speech landed on
+``no_answers`` ("no report") whenever the live model never called the
+``save_answer`` tool — everything the candidate said was silently dropped.
+``state.add_turn`` now tags each transcript turn with the active question id and
+``state.reconstruct_answers`` recovers those unsaved answers at shutdown, so the
+report pipeline scores them like any saved answer.
+
+Repo sharing: ``build_deps()`` (used inline by these tests, mirroring
+``test_live._build_context``) and every API route resolve to the SAME cached
+``Deps`` whose repo is the module-singleton ``MemoryRepository`` (conftest blanks
+the Supabase creds), so a session prepped inline is visible to the TestClient
+and vice versa — exactly the pattern ``test_app`` relies on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from deepinterview_agent.app import create_app
+from deepinterview_agent.core.deps import Deps, build_deps
+from deepinterview_agent.live import state
+from deepinterview_agent.live.state import InterviewUserdata
+from deepinterview_agent.prep import run_prep
+from deepinterview_agent.shared_models import (
+    LanguageMode,
+    PrepRequest,
+    ScoreCard,
+)
+
+# A substantive spoken answer (~50 words): comfortably above any thinness
+# threshold and unambiguously "real speech" for the recovery scenarios.
+_SPOKEN_ANSWER = (
+    "I led the incident response when our payments ledger started double-charging "
+    "customers. I traced the bug to a race between the retry worker and the "
+    "settlement job, added an idempotency key on every write, backfilled the "
+    "corrupted rows, and wrote a regression test so the failure mode can never "
+    "silently return."
+)
+
+_CURATED_ANSWER = "The model's curated answer for question one."
+
+
+def _client() -> TestClient:
+    return TestClient(create_app())
+
+
+def _prep_userdata() -> tuple[Deps, InterviewUserdata]:
+    """Run the offline prep pipeline and wrap the ready context for the live sim."""
+    deps = build_deps()
+    req = PrepRequest(
+        cv_url="https://example.com/cv.pdf",
+        jd_text="Senior Backend Engineer building distributed payment systems in Python.",
+        company="ExampleCorp",
+        language_mode=LanguageMode(primary="en", mixed=False),
+    )
+    session_id = asyncio.run(run_prep(req, deps))
+    ctx = asyncio.run(deps.repo.load_context(session_id))
+    assert ctx is not None, "prep must yield a ready context"
+    return deps, InterviewUserdata(ctx=ctx, session_id=ctx.session_id)
+
+
+def _add_behavioral_question(ud: InterviewUserdata) -> None:
+    """Augment the one-question mock plan with a second, different-section question."""
+    first = ud.ctx.plan.questions[0]
+    ud.ctx.plan.questions.append(
+        first.model_copy(update={"id": "q_behavioral", "section": "behavioral"})
+    )
+
+
+def _post_live_result(
+    client: TestClient, ud: InterviewUserdata, status: str | None = None
+) -> None:
+    """Replay the worker's shutdown write-back through the API (must 200)."""
+    payload: dict = {
+        "context": ud.ctx.model_dump(mode="json"),
+        "transcript": ud.transcript,
+        "status": status,
+    }
+    resp = client.post(f"/api/session/{ud.session_id}/live-result", json=payload)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True}
+
+
+def _post_score(client: TestClient, session_id: str) -> dict:
+    resp = client.post("/api/score", json={"session_id": session_id})
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _get_view(client: TestClient, session_id: str) -> dict:
+    resp = client.get(f"/api/session/{session_id}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _simulate_unsaved_interview(ud: InterviewUserdata) -> int:
+    """Speak a real answer WITHOUT save_answer, then run the shutdown recovery.
+
+    Mirrors worker._on_shutdown ordering: reconstruct_answers runs BEFORE any
+    has_answers decision or persistence. Returns the recovered-record count.
+    """
+    state.add_turn(ud, "assistant", "Tell me about a hard production bug you fixed.")
+    state.add_turn(ud, "user", _SPOKEN_ANSWER)
+    assert ud.ctx.answers == [], "precondition: the model never called save_answer"
+    return state.reconstruct_answers(ud)
+
+
+def test_happy_path_saved_answers_yields_complete_view_with_scorecard() -> None:
+    """prep -> save_answer + tagged turns -> live-result -> score -> view shows a
+    'complete' session with a numeric scorecard and the answers preserved."""
+    _deps, ud = _prep_userdata()
+    client = _client()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    # The live model behaved: it logged turns AND called the save_answer tool.
+    state.add_turn(ud, "assistant", q1.text.get("en", "First question."))
+    state.add_turn(ud, "user", _SPOKEN_ANSWER)
+    state.save_answer(
+        ud,
+        transcript=_SPOKEN_ANSWER,
+        started_at="2026-06-11T09:00:00Z",
+        ended_at="2026-06-11T09:02:00Z",
+    )
+
+    _post_live_result(client, ud)
+    _post_score(client, ud.session_id)
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "complete"
+    sc = view["scorecard"]
+    assert sc is not None
+    assert isinstance(sc["overall_score"], (int, float))
+    assert 0.0 <= sc["overall_score"] <= 5.0
+    # The answers the worker pushed survive in the served context.
+    answers = view["context"]["answers"]
+    assert len(answers) == 1
+    assert answers[0]["question_id"] == q1.id
+    assert answers[0]["transcript"] == _SPOKEN_ANSWER
+
+
+def test_recovery_when_save_answer_never_called_still_reaches_complete() -> None:
+    """THE production bug: real speech but the model never called save_answer.
+
+    reconstruct_answers must recover the spoken answer so the session scores to
+    'complete' with a scorecard — NOT land on no_answers ("no report")."""
+    _deps, ud = _prep_userdata()
+    client = _client()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    recovered = _simulate_unsaved_interview(ud)
+    assert recovered == 1
+    assert ud.ctx.answers[0].question_id == q1.id
+    assert ud.ctx.answers[0].transcript == _SPOKEN_ANSWER
+
+    # has_answers is now True -> the worker sends no terminal status hint.
+    _post_live_result(client, ud)
+    _post_score(client, ud.session_id)
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "complete"
+    assert view["status"] != "no_answers"
+    assert view["scorecard"] is not None
+    assert view["scorecard"]["competency_scores"], "recovered answer must be scored"
+
+
+def test_silent_call_stays_no_answers_and_score_does_not_fabricate() -> None:
+    """A call with NO user speech ends honestly: status no_answers, no scorecard
+    — and a later /api/score must not fabricate one or flip the status."""
+    deps, ud = _prep_userdata()
+    client = _client()
+
+    state.add_turn(ud, "assistant", "Tell me about a hard production bug you fixed.")
+    state.add_turn(ud, "assistant", "Hello? Are you still there?")
+    assert state.reconstruct_answers(ud) == 0
+    assert ud.ctx.answers == []
+
+    # has_answers is False -> the worker sends the terminal no_answers hint.
+    _post_live_result(client, ud, status="no_answers")
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "no_answers"
+    assert view["scorecard"] is None
+
+    # Scoring anyway (e.g. a manual retry) must not invent a report.
+    body = _post_score(client, ud.session_id)
+    assert body["scorecard"]["competency_scores"] == []
+    assert body["scorecard"]["overall_score"] == 0.0
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "no_answers"
+    assert view["scorecard"] is None
+    assert deps.repo._rows[ud.session_id].scorecard is None  # nothing persisted
+
+
+def test_mixed_saved_and_recovered_answers_score_and_curated_q1_wins() -> None:
+    """Q1 saved via the tool, Q2 only spoken: recovery adds EXACTLY the Q2 record,
+    never touches the curated Q1 one, and evaluator-style last-wins indexing
+    still resolves Q1 to the curated text."""
+    _deps, ud = _prep_userdata()
+    _add_behavioral_question(ud)
+    client = _client()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    # Q1: raw STT turn PLUS a curated save_answer call from the model. The raw
+    # speech clears the substance gate, so ONLY the qid-in-saved guard keeps
+    # recovery from adding a second Q1 record.
+    state.add_turn(ud, "assistant", "First question.")
+    state.add_turn(
+        ud, "user", "raw stt text for question one with enough words to clear the substance gate"
+    )
+    state.save_answer(ud, transcript=_CURATED_ANSWER, started_at="", ended_at="")
+    state.advance(ud)  # -> q_behavioral
+
+    # Q2: spoken only; the model forgot the tool.
+    state.add_turn(ud, "assistant", "Now a behavioral question.")
+    state.add_turn(ud, "user", _SPOKEN_ANSWER)
+
+    recovered = state.reconstruct_answers(ud)
+    assert recovered == 1
+    assert len(ud.ctx.answers) == 2
+    assert ud.ctx.answers[0].transcript == _CURATED_ANSWER  # untouched
+    assert ud.ctx.answers[1].question_id == "q_behavioral"
+    assert ud.ctx.answers[1].transcript == _SPOKEN_ANSWER
+
+    # The evaluator indexes answers by question id, last record winning — Q1
+    # must resolve to the CURATED text, not the raw STT turn.
+    by_id = {a.question_id: a for a in ud.ctx.answers}
+    assert by_id[q1.id].transcript == _CURATED_ANSWER
+
+    _post_live_result(client, ud)
+    _post_score(client, ud.session_id)
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "complete"
+    sc = ScoreCard.model_validate(view["scorecard"])
+    # Both questions count as answered: full coverage, a model answer for each.
+    assert sc.coverage_pct == 1.0
+    assert {ma.question_id for ma in sc.model_answers} == {q1.id, "q_behavioral"}
+
+
+def test_tagged_transcript_roundtrips_through_live_result() -> None:
+    """The question_id-tagged transcript persists VERBATIM through live-result,
+    keeping the tags reconstruct_answers (and any future audit) depends on."""
+    deps, ud = _prep_userdata()
+    client = _client()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    state.add_turn(ud, "assistant", "Tell me about a hard production bug you fixed.")
+    state.add_turn(ud, "user", _SPOKEN_ANSWER)
+
+    _post_live_result(client, ud)
+
+    persisted = deps.repo._rows[ud.session_id].transcript
+    assert persisted == ud.transcript
+    assert all("question_id" in turn for turn in persisted)
+    assert {turn["question_id"] for turn in persisted} == {q1.id}
+
+
+def test_scoring_idempotent_after_recovery_returns_persisted_card() -> None:
+    """A second /api/score after a recovered interview returns the SAME persisted
+    card (no re-scoring, no overwrite) and the session stays 'complete'."""
+    deps, ud = _prep_userdata()
+    client = _client()
+
+    assert _simulate_unsaved_interview(ud) == 1
+    _post_live_result(client, ud)
+
+    first = _post_score(client, ud.session_id)
+    second = _post_score(client, ud.session_id)
+
+    # Stable field AND the full card agree across calls.
+    assert second["scorecard"]["summary"] == first["scorecard"]["summary"]
+    assert second["scorecard"] == first["scorecard"]
+    # The second response IS the persisted card, byte-for-byte as a model.
+    persisted = ScoreCard.model_validate(deps.repo._rows[ud.session_id].scorecard)
+    assert ScoreCard.model_validate(second["scorecard"]) == persisted
+    assert _get_view(client, ud.session_id)["status"] == "complete"
+
+
+def test_empty_saved_answer_does_not_block_recovery() -> None:
+    """A save_answer call with a BLANK transcript must not count as 'saved':
+    the spoken answer for the same question is still recovered and scored."""
+    _deps, ud = _prep_userdata()
+    client = _client()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    # The model called the tool but passed an empty transcript...
+    state.save_answer(ud, transcript="", started_at="", ended_at="")
+    # ...while the candidate actually spoke a real answer to the same question.
+    state.add_turn(ud, "user", _SPOKEN_ANSWER)
+
+    recovered = state.reconstruct_answers(ud)
+    assert recovered == 1, "blank saved record must not suppress recovery"
+    assert ud.ctx.answers[-1].question_id == q1.id
+    assert ud.ctx.answers[-1].transcript == _SPOKEN_ANSWER
+
+    # Without recovery this session would have scored as no_answers.
+    _post_live_result(client, ud)
+    _post_score(client, ud.session_id)
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "complete"
+    assert view["scorecard"] is not None
+
+
+def test_live_result_disallowed_status_complete_is_ignored() -> None:
+    """The live-result status hint is a CLOSED set ({no_answers, error} only):
+    POSTing status='complete' must NOT flip the session to complete without a
+    scorecard — the request succeeds but the hint is dropped, and the view
+    still reads 'ready' with no scorecard. A refactor to a bare
+    ``if req.status: update_status(req.status)`` regresses exactly this."""
+    deps, ud = _prep_userdata()
+    client = _client()
+    state.add_turn(ud, "user", _SPOKEN_ANSWER)
+
+    _post_live_result(client, ud, status="complete")  # asserts the 200 + ok body
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "ready", "disallowed hint must leave the status alone"
+    assert view["scorecard"] is None
+    assert deps.repo.get_status(ud.session_id) == "ready"  # nothing hit the store
+
+
+def test_live_result_garbage_status_is_not_persisted_and_view_stays_readable() -> None:
+    """A garbage status must never be written: ``SessionView.status`` is a
+    Literal, so persisting it would make EVERY later ``GET /api/session/{id}``
+    raise ValidationError (500) — the failure class views.py warns about. The
+    write must be ignored and the subsequent GET must still 200."""
+    deps, ud = _prep_userdata()
+    client = _client()
+
+    _post_live_result(client, ud, status="garbage")
+
+    view = _get_view(client, ud.session_id)  # _get_view asserts the GET 200s
+    assert view["status"] == "ready"
+    assert deps.repo.get_status(ud.session_id) == "ready"
+    # The context write-back itself still landed (only the status was dropped).
+    assert view["context"] is not None
+
+
+def test_recovered_answer_reaches_report_as_answered_coverage() -> None:
+    """The recovered question id reads as ANSWERED in the report itself: full
+    coverage_pct, a model answer for it, and competencies drawn from the plan."""
+    _deps, ud = _prep_userdata()
+    client = _client()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    assert _simulate_unsaved_interview(ud) == 1
+    _post_live_result(client, ud)
+    _post_score(client, ud.session_id)
+
+    view = _get_view(client, ud.session_id)
+    assert view["status"] == "complete"
+    sc = ScoreCard.model_validate(view["scorecard"])
+
+    # The single-question mock plan was fully covered by the RECOVERED answer.
+    assert sc.coverage_pct == 1.0
+    assert {ma.question_id for ma in sc.model_answers} == {q1.id}
+    # The recovered answer produced real competency scores mapped to the plan.
+    plan_competencies = {q.target_competency for q in ud.ctx.plan.questions}
+    assert sc.competency_scores
+    assert {cs.competency for cs in sc.competency_scores} <= plan_competencies

--- a/apps/agent/tests/test_repository.py
+++ b/apps/agent/tests/test_repository.py
@@ -1,9 +1,28 @@
-"""Offline tests for the in-memory session repository."""
+"""Offline tests for the session repositories.
+
+``MemoryRepository`` is exercised directly. ``SupabaseRepository`` — the
+PRODUCTION persistence of the live-result write-back, scorecard save, status
+transitions, and the session-view read — is exercised through an injected fake
+recording client: ``_table()`` only imports the optional ``supabase`` SDK when
+``self._client is None``, so setting ``repo._client`` to a postgrest-shaped
+fake runs every real repository method offline (conftest blanks the creds, so
+nothing else in the suite ever constructs this class). The fake JSON-encodes
+every write payload exactly where the real SDK would, pinning that python-mode
+``model_dump()`` payloads stay JSON-safe on the hosted path too.
+"""
+
+from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
+from typing import Any
 
 from deepinterview_agent.core.adapters.mock import build_mock
-from deepinterview_agent.core.persistence.repository import MemoryRepository
+from deepinterview_agent.core.persistence.repository import (
+    MemoryRepository,
+    SupabaseRepository,
+)
 from deepinterview_agent.shared_models import (
     AnswerRecord,
     InterviewContext,
@@ -11,6 +30,9 @@ from deepinterview_agent.shared_models import (
     PrepRequest,
     ScoreCard,
 )
+
+# apps/agent/tests/ -> repo root -> the migrations that define public.sessions.
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "supabase" / "migrations"
 
 
 def _run(coro):
@@ -98,3 +120,213 @@ def test_append_answer_and_save_scorecard() -> None:
     _run(repo.save_scorecard(session_id, scorecard))
 
     _run(repo.save_transcript(session_id, [{"role": "agent", "text": "hi"}]))
+
+
+# --- SupabaseRepository via an injected fake recording client -----------------
+
+
+class _FakeSupabaseResponse:
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+class _FakeSessionsTable:
+    """One postgrest-style chained call (insert/update/select … execute).
+
+    Executes against a shared in-memory row store and appends
+    ``(op, payload_or_columns, session_id)`` to the shared log. Every WRITE
+    payload is ``json.dumps``-encoded first — the boundary where the real SDK
+    serializes — so a non-JSON type (datetime/enum) added to a model breaks
+    these tests instead of only the hosted deployment.
+    """
+
+    def __init__(self, store: dict[str, dict], log: list[tuple]) -> None:
+        self._store = store
+        self._log = log
+        self._op: str | None = None
+        self._payload: Any = None
+        self._cols: str | None = None
+        self._id: str | None = None
+
+    def insert(self, payload: dict) -> _FakeSessionsTable:
+        self._op, self._payload = "insert", payload
+        return self
+
+    def update(self, values: dict) -> _FakeSessionsTable:
+        self._op, self._payload = "update", values
+        return self
+
+    def select(self, cols: str) -> _FakeSessionsTable:
+        self._op, self._cols = "select", cols
+        return self
+
+    def eq(self, col: str, value: str) -> _FakeSessionsTable:
+        assert col == "id", "the repository only ever filters by primary key"
+        self._id = value
+        return self
+
+    def limit(self, n: int) -> _FakeSessionsTable:
+        return self
+
+    def execute(self) -> _FakeSupabaseResponse:
+        if self._op == "insert":
+            json.dumps(self._payload)  # the SDK JSON-encodes; non-JSON fails HERE
+            self._log.append(("insert", self._payload, self._payload["id"]))
+            self._store[self._payload["id"]] = dict(self._payload)
+            return _FakeSupabaseResponse([self._payload])
+        if self._op == "update":
+            json.dumps(self._payload)
+            self._log.append(("update", self._payload, self._id))
+            row = self._store.get(self._id or "")
+            if row is not None:
+                row.update(self._payload)
+            return _FakeSupabaseResponse([row] if row is not None else [])
+        assert self._op == "select"
+        self._log.append(("select", self._cols, self._id))
+        row = self._store.get(self._id or "")
+        if row is None:
+            return _FakeSupabaseResponse([])
+        cols = [c.strip() for c in (self._cols or "").split(",")]
+        return _FakeSupabaseResponse([{c: row.get(c) for c in cols}])
+
+
+class _FakeSupabaseClient:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict] = {}
+        self.log: list[tuple] = []
+
+    def table(self, name: str) -> _FakeSessionsTable:
+        assert name == "sessions", "all session persistence lives in public.sessions"
+        return _FakeSessionsTable(self.rows, self.log)
+
+
+def _supabase_repo() -> tuple[SupabaseRepository, _FakeSupabaseClient]:
+    repo = SupabaseRepository("https://example.supabase.co", "service-role-key")
+    fake = _FakeSupabaseClient()
+    repo._client = fake  # _table() only imports the SDK when _client is None
+    return repo, fake
+
+
+def test_supabase_create_and_context_round_trip_payloads_are_json_safe() -> None:
+    """create_session/save_context write python-mode ``model_dump()`` payloads:
+    they must stay JSON-encodable AND round-trip through ``load_context`` —
+    the exact read the scoring pipeline performs on the hosted path."""
+    repo, fake = _supabase_repo()
+    session_id = _run(repo.create_session(_prep_request()))
+    assert session_id.startswith("sess_")
+    assert fake.rows[session_id]["status"] == "prep"
+    assert fake.rows[session_id]["jd_text"] == "We are hiring a backend engineer."
+
+    ctx = build_mock(InterviewContext)
+    assert isinstance(ctx, InterviewContext)
+    _run(repo.save_context(session_id, ctx))  # raises in execute() if non-JSON
+
+    loaded = _run(repo.load_context(session_id))
+    assert loaded is not None
+    assert loaded.model_dump() == ctx.model_dump()
+    # Unknown ids read as None, never raise (the worker treats this as "not ready").
+    assert _run(repo.load_context("sess_missing")) is None
+
+
+def test_supabase_create_session_stamps_user_id_column() -> None:
+    """The RLS ownership column (report bug, PR #5) must land on the INSERT
+    payload on the Supabase path too — auth.uid() = user_id reads depend on it."""
+    repo, fake = _supabase_repo()
+    owner = "11111111-2222-3333-4444-555555555555"
+    sid = _run(repo.create_session(_prep_request().model_copy(update={"user_id": owner})))
+    assert fake.rows[sid]["user_id"] == owner
+    anon = _run(repo.create_session(_prep_request()))
+    assert fake.rows[anon]["user_id"] is None
+
+
+def test_supabase_update_status_writes_each_live_terminal_status() -> None:
+    """The live path's status transitions (no_answers / error / complete) must
+    each become a ``{"status": ...}`` update against the row."""
+    repo, fake = _supabase_repo()
+    sid = _run(repo.create_session(_prep_request()))
+    for status in ("no_answers", "error", "complete"):
+        _run(repo.update_status(sid, status))
+        assert fake.rows[sid]["status"] == status
+        assert ("update", {"status": status}, sid) in fake.log
+
+
+def test_supabase_save_scorecard_payload_is_json_encodable() -> None:
+    """save_scorecard ships ``sc.model_dump()`` (python mode) to the SDK: it
+    must JSON-encode and land in the ``scorecard`` column unchanged."""
+    repo, fake = _supabase_repo()
+    sid = _run(repo.create_session(_prep_request()))
+    sc = build_mock(ScoreCard)
+    assert isinstance(sc, ScoreCard)
+    _run(repo.save_scorecard(sid, sc))  # raises in execute() if non-JSON
+    assert fake.rows[sid]["scorecard"] == sc.model_dump()
+
+
+def test_supabase_append_answer_read_modify_writes_the_context_blob() -> None:
+    """Supabase ``append_answer`` mutates the canonical context blob (the
+    Memory/Supabase asymmetry test_score.py's docstring warns about): the
+    appended answer must be visible to a later ``load_context``. With no
+    context saved yet it is a silent no-op (no update issued)."""
+    repo, fake = _supabase_repo()
+    sid = _run(repo.create_session(_prep_request()))
+    ctx = build_mock(InterviewContext)
+    assert isinstance(ctx, InterviewContext)
+    base_answers = len(ctx.answers)
+    _run(repo.save_context(sid, ctx))
+
+    answer = AnswerRecord(
+        question_id="q1",
+        transcript="A real spoken answer.",
+        started_at="2026-06-11T09:00:00Z",
+        ended_at="2026-06-11T09:01:00Z",
+    )
+    _run(repo.append_answer(sid, answer))
+
+    loaded = _run(repo.load_context(sid))
+    assert loaded is not None
+    assert len(loaded.answers) == base_answers + 1
+    assert loaded.answers[-1].model_dump() == answer.model_dump()
+
+    # No context yet -> append must not write anything.
+    sid2 = _run(repo.create_session(_prep_request()))
+    updates_before = len([op for op, *_ in fake.log if op == "update"])
+    _run(repo.append_answer(sid2, answer))
+    assert len([op for op, *_ in fake.log if op == "update"]) == updates_before
+
+
+def test_supabase_get_session_view_selects_migration_columns_and_maps_row() -> None:
+    """``get_session_view`` must select exactly the columns the migrations
+    create and map them onto SessionView (status/progress/prep_warnings/
+    context/scorecard) — a renamed or dropped column fails here, not only in
+    the hosted deployment."""
+    repo, fake = _supabase_repo()
+    sid = _run(repo.create_session(_prep_request()))
+    ctx = build_mock(InterviewContext)
+    sc = build_mock(ScoreCard)
+    _run(repo.save_context(sid, ctx))
+    _run(repo.save_scorecard(sid, sc))
+    _run(repo.mark_progress(sid, "cv_analysis"))
+    _run(repo.mark_progress(sid, "cv_analysis"))  # idempotent: no duplicate
+    _run(repo.add_warnings(sid, ["JD text is very short."]))
+    _run(repo.update_status(sid, "complete"))
+
+    view = _run(repo.get_session_view(sid))
+    assert view is not None
+    assert (view.session_id, view.status) == (sid, "complete")
+    assert view.progress == ["cv_analysis"]
+    assert view.prep_warnings == ["JD text is very short."]
+    assert view.context is not None
+    assert view.context.model_dump() == ctx.model_dump()
+    assert view.scorecard is not None
+    assert view.scorecard.model_dump() == sc.model_dump()
+
+    # Pin the select column list against what the migrations actually create.
+    select_cols = [cols for op, cols, row_id in fake.log if op == "select" and row_id == sid][-1]
+    assert select_cols == "id,status,progress,prep_warnings,context,scorecard"
+    migration_files = sorted(_MIGRATIONS_DIR.glob("*.sql"))
+    assert migration_files, f"no migrations found under {_MIGRATIONS_DIR}"
+    migrations_sql = "".join(p.read_text() for p in migration_files)
+    for col in select_cols.split(","):
+        assert col in migrations_sql, f"selected column {col!r} not defined by any migration"
+
+    # Unknown ids map to None (the API turns this into a 404, not a 500).
+    assert _run(repo.get_session_view("sess_missing")) is None

--- a/apps/agent/tests/test_score.py
+++ b/apps/agent/tests/test_score.py
@@ -175,6 +175,40 @@ def test_run_score_skips_when_no_answers() -> None:
     assert deps.repo.get_status(session_id) == "no_answers"
 
 
+def test_run_score_skips_when_all_answers_are_blank() -> None:
+    """Answers whose transcripts are ALL empty/whitespace count as NO answers.
+
+    The guard is ``not any((a.transcript or '').strip() ...)`` — NOT a bare
+    ``if not ctx.answers``. A session whose only records are ``save_answer("")``
+    calls (the model fired the tool with empty text, no recoverable speech)
+    must land on ``no_answers`` with NO persisted scorecard, never flow into
+    evaluate and ship a misleading all-zeros 'complete' card."""
+    deps = build_deps()
+    session_id = asyncio.run(run_prep(_request(), deps))
+    ctx = asyncio.run(deps.repo.load_context(session_id))
+    assert ctx is not None
+    question_id = ctx.plan.questions[0].id
+    for blank in ("", "   "):
+        ctx.answers.append(
+            AnswerRecord(
+                question_id=question_id, transcript=blank, started_at="", ended_at=""
+            )
+        )
+    asyncio.run(deps.repo.save_context(session_id, ctx))
+    assert ctx.answers, "precondition: the answers list itself is non-empty"
+
+    sc = asyncio.run(run_score(ScoreRequest(session_id=session_id), deps))
+
+    # A well-formed empty card is returned for the direct caller...
+    assert isinstance(sc, ScoreCard)
+    assert sc.competency_scores == []
+    assert sc.overall_score == 0.0
+    assert sc.coverage_pct == 0.0
+    # ...the session is flagged no_answers (NOT complete), nothing persisted.
+    assert deps.repo.get_status(session_id) == "no_answers"
+    assert deps.repo._rows[session_id].scorecard is None
+
+
 def test_run_score_reports_partial_coverage() -> None:
     """Unanswered questions lower coverage_pct and never count as weak."""
     deps = build_deps()

--- a/apps/agent/tests/test_worker_livekit.py
+++ b/apps/agent/tests/test_worker_livekit.py
@@ -1,0 +1,588 @@
+"""Regression tests for the livekit-COUPLED pieces of the WP-5 worker.
+
+Unlike ``test_live.py`` (which pins the pure ``live.state`` machine), this module
+imports ``deepinterview_agent.worker`` — which imports ``livekit.agents`` at load
+time — so it SKIPS cleanly wherever the optional ``livekit`` extra is absent
+(plain CI venv) and RUNS inside the worker docker image (``uv sync --extra
+livekit``). Everything stays offline and deterministic: no provider construction
+here performs network I/O (verified against the installed plugin source — the
+Deepgram ``STT.__init__`` only validates kwargs and builds an ``STTOptions``
+dataclass), and the ``InterviewContext`` comes from the WP-6 prep pipeline with
+the mock adapters forced by ``conftest.py``.
+
+What is pinned, and why it must not regress:
+
+* ``wire_transcript_capture`` — the shutdown-time answer recovery
+  (``state.reconstruct_answers``) can only recover what this wiring captured,
+  tagged with the question active when it was spoken. If the
+  ``conversation_item_added`` hookup or its question_id tagging breaks, sessions
+  with real speech silently land on ``no_answers`` ("no report") again.
+* ``_deepgram_stt`` / ``build_stt`` — plugin kwargs are passed positionally by
+  name into ``deepgram.STT``; a plugin signature drift would raise at session
+  start and break EVERY interview. The language→model routing (non-English →
+  nova-2) exists because nova-3 streams NO Vietnamese transcripts (confirmed
+  live 2026-06-10), and the per-model ``endpointing_ms`` split (25 vs 300)
+  keeps Vietnamese answers from being chopped into fragments.
+* ``entrypoint``'s REAL ``_on_shutdown`` closure — driven end-to-end with every
+  livekit-coupled seam faked (no room, no providers, no network). This is the
+  write-back that fixed the production "no report" bug, and it only exists as
+  a closure: ``state.reconstruct_answers`` must run BEFORE ``has_answers`` is
+  computed, the live-result POST must carry the ``no_answers`` hint only for
+  truly answer-less sessions, the API→repo fallback order (and the
+  save_context-failure → ``error`` branch) must hold, the payload built from
+  python-mode ``ctx.model_dump()`` must stay JSON-encodable AND parse as the
+  API's ``LiveResultRequest``, and scoring must fire only after a successful
+  persist of a session with real answers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+pytest.importorskip("livekit.agents")
+
+from deepinterview_agent import worker  # noqa: E402
+from deepinterview_agent.api.session import LiveResultRequest  # noqa: E402
+from deepinterview_agent.core.deps import build_deps  # noqa: E402
+from deepinterview_agent.live import state  # noqa: E402
+from deepinterview_agent.live.state import InterviewUserdata  # noqa: E402
+from deepinterview_agent.prep import run_prep  # noqa: E402
+from deepinterview_agent.shared_models import (  # noqa: E402
+    InterviewContext,
+    LanguageMode,
+    PrepRequest,
+)
+
+# --- helpers (same construction as tests/test_live.py) -----------------------
+
+
+def _build_context() -> InterviewContext:
+    """Run the offline prep pipeline and load the resulting InterviewContext."""
+    deps = build_deps()
+    req = PrepRequest(
+        cv_url="https://example.com/cv.pdf",
+        jd_text="Senior Backend Engineer building distributed payment systems in Python.",
+        company="ExampleCorp",
+        language_mode=LanguageMode(primary="en", mixed=False),
+    )
+    session_id = asyncio.run(run_prep(req, deps))
+    ctx = asyncio.run(deps.repo.load_context(session_id))
+    assert ctx is not None
+    return ctx
+
+
+def _userdata_two_sections() -> InterviewUserdata:
+    """Userdata whose plan has a second question in a different section.
+
+    The mock plan carries exactly one question (section ``intro``); a second
+    one lets the tests observe the question_id tag CHANGE when the cursor
+    advances.
+    """
+    ctx = _build_context()
+    first = ctx.plan.questions[0]
+    second = first.model_copy(update={"id": "q_behavioral", "section": "behavioral"})
+    ctx.plan.questions.append(second)
+    return InterviewUserdata(ctx=ctx, session_id=ctx.session_id)
+
+
+class FakeAgentSession:
+    """Minimal stand-in for the ``AgentSession`` event surface the worker uses.
+
+    ``wire_transcript_capture`` registers via the EventEmitter decorator form
+    ``@session.on("conversation_item_added")`` — i.e. ``.on(event)`` with no
+    callback returns a decorator (mirrors ``livekit.agents``' ``EventEmitter.on``,
+    which also accepts ``.on(event, callback)`` directly). ``emit`` then fires
+    the registered handlers synchronously, exactly like the SDK does.
+    """
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, list[Callable[..., Any]]] = {}
+
+    def on(
+        self, event: str, callback: Callable[..., Any] | None = None
+    ) -> Callable[..., Any]:
+        if callback is not None:
+            self.handlers.setdefault(event, []).append(callback)
+            return callback
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            self.handlers.setdefault(event, []).append(fn)
+            return fn
+
+        return decorator
+
+    def emit(self, event: str, ev: Any) -> None:
+        for handler in self.handlers.get(event, []):
+            handler(ev)
+
+
+def _item_event(role: Any, text: Any) -> SimpleNamespace:
+    """A fake ``conversation_item_added`` event: ``ev.item.role`` / ``.text_content``."""
+    return SimpleNamespace(item=SimpleNamespace(role=role, text_content=text))
+
+
+# --- wire_transcript_capture --------------------------------------------------
+
+
+def test_wire_transcript_capture_tags_turns() -> None:
+    """Committed turns land in userdata.transcript tagged with the ACTIVE question.
+
+    This tag is what ``state.reconstruct_answers`` keys on at shutdown — lose it
+    and unsaved answers can no longer be recovered per question.
+    """
+    ud = _userdata_two_sections()
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    session = FakeAgentSession()
+    worker.wire_transcript_capture(session, ud)
+    assert session.handlers.get("conversation_item_added"), (
+        "wire_transcript_capture must register on conversation_item_added"
+    )
+
+    session.emit(
+        "conversation_item_added",
+        _item_event("user", "I traced a race condition in our ledger writer."),
+    )
+    assert ud.transcript == [
+        {
+            "role": "user",
+            "text": "I traced a race condition in our ledger writer.",
+            "question_id": q1.id,
+        }
+    ]
+
+    # Advance the cursor to the second question: subsequent turns must carry
+    # the NEW question's id, not the stale one.
+    state.advance(ud)
+    session.emit(
+        "conversation_item_added",
+        _item_event("assistant", "Tell me about a time you led a team."),
+    )
+    assert ud.transcript[-1] == {
+        "role": "assistant",
+        "text": "Tell me about a time you led a team.",
+        "question_id": "q_behavioral",
+    }
+    assert len(ud.transcript) == 2
+
+
+def test_wire_transcript_capture_ignores_non_turns() -> None:
+    """Events without a user/assistant role or without text must not append."""
+    ud = _userdata_two_sections()
+    session = FakeAgentSession()
+    worker.wire_transcript_capture(session, ud)
+
+    session.emit("conversation_item_added", _item_event(None, "text with no role"))
+    session.emit("conversation_item_added", _item_event("user", ""))
+    session.emit("conversation_item_added", _item_event("user", None))
+    session.emit("conversation_item_added", _item_event("assistant", ""))
+    session.emit("conversation_item_added", _item_event("system", "function call noise"))
+
+    assert ud.transcript == []
+
+
+# --- Deepgram STT construction + routing --------------------------------------
+
+
+def test_deepgram_stt_kwargs_are_valid() -> None:
+    """Both tuned kwarg sets must CONSTRUCT against the installed plugin.
+
+    ``_deepgram_stt`` passes its kwargs straight into ``deepgram.STT``; a plugin
+    signature drift (renamed/removed kwarg) raises here instead of at the start
+    of every live session. Construction is offline: the plugin ``__init__`` only
+    validates and stores options, so a dummy ``api_key="x"`` suffices. Also pins
+    the documented per-model endpointing split: nova-3 rides the semantic EOU
+    model (25ms), nova-2 needs Deepgram's own 300ms silence window so languages
+    with within-utterance pauses (e.g. Vietnamese) aren't fragmented.
+    """
+    pytest.importorskip("livekit.plugins.deepgram")
+
+    stt_en = worker._deepgram_stt("en", "nova-3", api_key="x")
+    stt_vi = worker._deepgram_stt("vi", "nova-2", api_key="x")
+
+    assert stt_en._opts.model == "nova-3"
+    assert stt_en._opts.language == "en"
+    assert stt_en._opts.endpointing_ms == 25
+
+    assert stt_vi._opts.model == "nova-2"
+    assert stt_vi._opts.language == "vi"
+    assert stt_vi._opts.endpointing_ms == 300
+    # smart_format=True applies to both tiers (language-native number/date
+    # formatting).
+    assert stt_vi._opts.smart_format is True
+    assert stt_en._opts.smart_format is True
+
+    # numerals stays on the nova-3 tier only: the nova-2 tier keeps a minimal
+    # flag set because unsupported combos fail SILENTLY with zero transcripts
+    # (the exact vi failure mode debugged live 2026-06-10).
+    assert stt_en._opts.numerals is True
+    assert stt_vi._opts.numerals is False
+
+
+def test_build_stt_language_routing() -> None:
+    """build_stt routes language → model: vi→nova-2, en→nova-3, mixed→multi/nova-3.
+
+    nova-3 streams NO Vietnamese transcripts (confirmed live 2026-06-10), so
+    every non-English/multi language MUST route to nova-2; code-switching
+    sessions use Deepgram's "multi" on nova-3.
+    """
+    pytest.importorskip("livekit.plugins.deepgram")
+    settings = SimpleNamespace(stt_provider="deepgram", deepgram_api_key="x")
+
+    vi = worker.build_stt(settings, "vi")
+    assert (vi._opts.model, str(vi._opts.language)) == ("nova-2", "vi")
+
+    en = worker.build_stt(settings, "en")
+    assert (en._opts.model, str(en._opts.language)) == ("nova-3", "en")
+
+    mixed = worker.build_stt(settings, "vi", mixed=True)
+    assert (mixed._opts.model, str(mixed._opts.language)) == ("nova-3", "multi")
+
+
+# --- the REAL _on_shutdown closure (entrypoint driven with faked seams) --------
+#
+# ``_on_shutdown`` is a closure inside ``worker.entrypoint``; it cannot be
+# imported, only registered. So these tests run the genuine ``entrypoint`` with
+# every livekit-coupled collaborator replaced by an offline fake (the session,
+# room, director, guard, providers, and httpx), capture the callback it
+# registers via ``ctx.add_shutdown_callback``, mutate the live state exactly as
+# a real call would, and then invoke the callback. Whatever ordering bug is
+# reintroduced inside the closure fails HERE, not in production.
+
+_SPOKEN = (
+    "I led the incident response when our payments ledger started double-charging "
+    "customers, traced it to a race between the retry worker and the settlement "
+    "job, and added an idempotency key on every write."
+)
+
+
+class _RecordingHttpx:
+    """Stand-in for ``httpx.AsyncClient``: records POSTs, never touches the network.
+
+    ``json.dumps`` runs at the exact boundary where the real client serializes
+    ``json=`` — so a non-JSON-encodable field (datetime/enum) sneaking into the
+    worker's python-mode ``ctx.model_dump()`` payload fails here exactly as it
+    would in production.
+    """
+
+    def __init__(self, live_result_ok: bool = True) -> None:
+        self.posts: list[tuple[str, Any]] = []
+        self.live_result_ok = live_result_ok
+
+    def urls(self) -> list[str]:
+        return [url for url, _ in self.posts]
+
+    def client_cls(self) -> type:
+        recorder = self
+        dumps = json.dumps
+
+        class _Client:
+            def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+            async def __aenter__(self) -> _Client:
+                return self
+
+            async def __aexit__(self, *exc: Any) -> bool:
+                return False
+
+            async def post(self, url: str, json: Any = None) -> SimpleNamespace:  # noqa: A002 - mirrors httpx
+                dumps(json)  # what the real client does with json=
+                recorder.posts.append((url, json))
+                if url.endswith("/live-result") and not recorder.live_result_ok:
+                    raise RuntimeError("api unreachable")
+                return SimpleNamespace(status_code=200)
+
+        return _Client
+
+
+class _RecordingRepo:
+    """Wraps the real repo, recording the direct-store calls the fallback makes."""
+
+    def __init__(self, inner: Any, fail_save_context: bool = False) -> None:
+        self.inner = inner
+        self.calls: list[tuple[str, str]] = []
+        self.fail_save_context = fail_save_context
+
+    async def save_transcript(self, session_id: str, turns: list[dict]) -> None:
+        self.calls.append(("save_transcript", session_id))
+        await self.inner.save_transcript(session_id, turns)
+
+    async def save_context(self, session_id: str, ctx: Any) -> None:
+        self.calls.append(("save_context", session_id))
+        if self.fail_save_context:
+            raise RuntimeError("store down")
+        await self.inner.save_context(session_id, ctx)
+
+    async def update_status(self, session_id: str, status: str) -> None:
+        self.calls.append((f"update_status:{status}", session_id))
+        await self.inner.update_status(session_id, status)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.inner, name)
+
+
+class _FakeRoom(FakeAgentSession):
+    """Bare room surface: ``.on`` decorators plus the identity fields read by
+    ``wire_audio_path_logging`` / ``_session_id_from_room`` (metadata=None →
+    the session id is the room name)."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+        self.metadata = None
+        self.remote_participants: dict[str, Any] = {}
+
+
+class _FakeJobContext:
+    def __init__(self, room: _FakeRoom) -> None:
+        self.room = room
+        self.proc = SimpleNamespace(userdata={})
+        self.shutdown_callbacks: list[Callable[[], Any]] = []
+
+    async def connect(self) -> None:
+        return None
+
+    def add_shutdown_callback(self, cb: Callable[[], Any]) -> None:
+        self.shutdown_callbacks.append(cb)
+
+
+class _FakeLifecycle:
+    """Stands in for Director / SessionGuard: sync start(), async aclose()."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def start(self) -> None: ...
+
+    async def aclose(self) -> None: ...
+
+
+class _FakeUsageCollector:
+    def collect(self, m: Any) -> None: ...
+
+    def get_summary(self) -> dict:
+        return {}
+
+
+def _drive_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    live_result_ok: bool = True,
+    fail_save_context: bool = False,
+) -> SimpleNamespace:
+    """Run the real ``worker.entrypoint`` offline and capture its shutdown closure.
+
+    Only livekit/network seams are faked; the persistence ordering, the
+    has_answers decision, the payload construction and the scoring trigger all
+    run the REAL closure code. Returns the registered shutdown callback, the
+    live userdata, and the http/repo recorders.
+    """
+    interview_ctx = _build_context()
+    session_id = interview_ctx.session_id
+
+    rec_http = _RecordingHttpx(live_result_ok=live_result_ok)
+    rec_repo = _RecordingRepo(build_deps().repo, fail_save_context=fail_save_context)
+    deps = replace(build_deps(), repo=rec_repo)
+
+    async def _fake_load(sid: str, settings: Any) -> Any:
+        assert sid == session_id
+        return interview_ctx
+
+    sessions: list[FakeAgentSession] = []
+
+    class _FakeSession(FakeAgentSession):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__()
+            self.kwargs = kwargs
+            sessions.append(self)
+
+        async def start(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+    monkeypatch.setattr(worker, "_load_context_via_api", _fake_load)
+    monkeypatch.setattr(worker, "build_deps", lambda settings=None: deps)
+    monkeypatch.setattr(worker, "AgentSession", _FakeSession)
+    monkeypatch.setattr(
+        worker, "Interviewer", lambda userdata: SimpleNamespace(userdata=userdata)
+    )
+    monkeypatch.setattr(worker, "Director", _FakeLifecycle)
+    monkeypatch.setattr(worker, "SessionGuard", _FakeLifecycle)
+    monkeypatch.setattr(
+        worker, "metrics", SimpleNamespace(UsageCollector=_FakeUsageCollector)
+    )
+    for factory in ("build_stt", "build_llm", "build_tts", "build_vad"):
+        monkeypatch.setattr(worker, factory, lambda *a, **k: None)
+    monkeypatch.setattr(worker, "build_turn_handling", lambda *a, **k: {})
+    monkeypatch.setattr(worker, "build_room_options", lambda *a, **k: None)
+    monkeypatch.setattr(httpx, "AsyncClient", rec_http.client_cls())
+
+    job_ctx = _FakeJobContext(_FakeRoom(session_id))
+    asyncio.run(worker.entrypoint(job_ctx))
+
+    assert len(job_ctx.shutdown_callbacks) == 1, (
+        "entrypoint must register exactly one shutdown callback"
+    )
+    assert len(sessions) == 1
+    userdata = sessions[0].kwargs["userdata"]
+    assert userdata.session_id == session_id
+
+    return SimpleNamespace(
+        shutdown=job_ctx.shutdown_callbacks[0],
+        userdata=userdata,
+        http=rec_http,
+        repo=rec_repo,
+        session_id=session_id,
+    )
+
+
+def test_shutdown_recovers_unsaved_answers_before_deciding_has_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE production-bug ordering, in the real closure: real speech with NO
+    save_answer call must reach the live-result payload as a recovered answer
+    with status hint None — and scoring must fire AFTER the persist. Deleting
+    or reordering ``state.reconstruct_answers`` (or computing ``has_answers``
+    before it) flips the payload to ``no_answers`` and kills the score POST."""
+    drive = _drive_entrypoint(monkeypatch)
+    ud = drive.userdata
+    q1 = state.current_question(ud)
+    assert q1 is not None
+
+    state.add_turn(ud, "assistant", "Tell me about a hard production bug you fixed.")
+    state.add_turn(ud, "user", _SPOKEN)
+    assert ud.ctx.answers == [], "precondition: the model never called save_answer"
+
+    asyncio.run(drive.shutdown())
+
+    assert len(drive.http.posts) == 2, "exactly: live-result persist, then score"
+    url, payload = drive.http.posts[0]
+    assert url.endswith(f"/api/session/{drive.session_id}/live-result")
+    assert payload["status"] is None, (
+        "recovered speech counts as answers — no terminal no_answers hint"
+    )
+    answers = payload["context"]["answers"]
+    assert [a["question_id"] for a in answers] == [q1.id]
+    assert answers[0]["transcript"] == _SPOKEN
+    # Persist first, score second — and only against this session.
+    score_url, score_body = drive.http.posts[1]
+    assert score_url.endswith("/api/score")
+    assert score_body == {"session_id": drive.session_id}
+    # The API persist succeeded, so the direct-repo fallback must stay untouched.
+    assert drive.repo.calls == []
+
+
+def test_shutdown_payload_is_json_encodable_and_parses_as_live_result_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The worker builds its payload with python-mode ``ctx.model_dump()`` and
+    hands it to httpx ``json=``: it must stay ``json.dumps``-encodable AND
+    validate as the API's ``LiveResultRequest`` (the worker→API wire contract).
+    A datetime/enum field added to InterviewContext breaks this first."""
+    drive = _drive_entrypoint(monkeypatch)
+    ud = drive.userdata
+    state.add_turn(ud, "user", _SPOKEN)
+    state.save_answer(
+        ud,
+        transcript=_SPOKEN,
+        started_at="2026-06-11T09:00:00Z",
+        ended_at="2026-06-11T09:02:00Z",
+    )
+
+    asyncio.run(drive.shutdown())
+
+    url, payload = drive.http.posts[0]
+    assert url.endswith("/live-result")
+    json.dumps(payload)  # the fake client also dumps at the boundary
+    req = LiveResultRequest.model_validate(payload)
+    assert req.transcript == ud.transcript
+    assert [a.transcript for a in req.context.answers] == [_SPOKEN]
+    assert req.status is None
+
+
+def test_shutdown_silent_call_sends_no_answers_hint_and_skips_scoring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A call with no user speech must POST the terminal ``no_answers`` hint and
+    must NOT trigger scoring (which would read an answer-less context)."""
+    drive = _drive_entrypoint(monkeypatch)
+    state.add_turn(drive.userdata, "assistant", "Hello? Are you still there?")
+
+    asyncio.run(drive.shutdown())
+
+    url, payload = drive.http.posts[0]
+    assert url.endswith("/live-result")
+    assert payload["status"] == "no_answers"
+    assert payload["context"]["answers"] == []
+    assert not any(u.endswith("/api/score") for u in drive.http.urls())
+
+
+def test_shutdown_blank_saved_answers_still_count_as_no_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``has_answers`` uses the non-empty-transcript rule, not list truthiness:
+    a lone ``save_answer("")`` with no recoverable speech keeps the
+    ``no_answers`` hint and skips scoring (no all-zeros card downstream)."""
+    drive = _drive_entrypoint(monkeypatch)
+    state.save_answer(drive.userdata, transcript="", started_at="", ended_at="")
+
+    asyncio.run(drive.shutdown())
+
+    assert drive.http.posts[0][1]["status"] == "no_answers"
+    assert not any(u.endswith("/api/score") for u in drive.http.urls())
+
+
+def test_shutdown_falls_back_to_repo_when_api_post_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API-first, direct-repo second: when the live-result POST raises, the
+    fallback persists transcript THEN context (answers included) to the shared
+    store, leaves the status untouched for an answered session, and scoring
+    still fires off the successful repo persist."""
+    drive = _drive_entrypoint(monkeypatch, live_result_ok=False)
+    ud = drive.userdata
+    q1 = state.current_question(ud)
+    assert q1 is not None
+    state.add_turn(ud, "user", _SPOKEN)
+
+    asyncio.run(drive.shutdown())
+
+    # The API path was attempted FIRST...
+    assert drive.http.urls()[0].endswith("/live-result")
+    # ...then the repo fallback persisted everything, in write order.
+    assert drive.repo.calls == [
+        ("save_transcript", drive.session_id),
+        ("save_context", drive.session_id),
+    ]
+    repo = build_deps().repo  # the memory singleton behind the recorder
+    persisted = asyncio.run(repo.load_context(drive.session_id))
+    assert persisted is not None
+    assert [a.question_id for a in persisted.answers] == [q1.id]
+    assert persisted.answers[0].transcript == _SPOKEN
+    # has_answers is True -> the fallback must NOT flip the status to no_answers.
+    assert repo.get_status(drive.session_id) == "ready"
+    # Repo persist succeeded for an answered session -> scoring still triggered.
+    assert drive.http.urls()[-1].endswith("/api/score")
+
+
+def test_shutdown_repo_save_context_failure_marks_error_and_skips_scoring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The only ready→error transition on the live path: when BOTH the API POST
+    and the fallback ``save_context`` fail, answers were NOT persisted — the
+    session is marked ``error`` (honest report, not zeros) and scoring is
+    skipped (it would score the answer-less prep-time context)."""
+    drive = _drive_entrypoint(monkeypatch, live_result_ok=False, fail_save_context=True)
+    state.add_turn(drive.userdata, "user", _SPOKEN)
+
+    asyncio.run(drive.shutdown())
+
+    assert ("update_status:error", drive.session_id) in drive.repo.calls
+    assert build_deps().repo.get_status(drive.session_id) == "error"
+    assert not any(u.endswith("/api/score") for u in drive.http.urls())


### PR DESCRIPTION
## Problem

Ending a call showed "No answers recorded" (no report) even when the candidate had answered. Answers reached scoring **only** when the live LLM called the `save_answer` tool — if the model forgot, or the candidate ended the call mid-question, everything in the verbatim transcript was discarded and the session landed on `no_answers`. Every session on 2026-06-10 after the first hit this.

## Fix

- `add_turn` tags each transcript turn with the active `question_id`.
- New `state.reconstruct_answers()` runs in the worker's shutdown callback **before** `has_answers` is computed: it joins unsaved user turns per question into `AnswerRecord`s.
- **Substance gate** (`_MIN_RECOVERED_WORDS = 12`): small talk ("Hi, nice to meet you!", "Có") is never recovered, so contentless calls keep the honest `no_answers` empty state instead of firing the LLM scoring pipeline on junk and producing a misleading near-zero report.
- **Last-wins saved-guard**: a question counts as saved only if its *last* record has substance, matching the scorers' `{question_id: answer}` indexing — a trailing `save_answer("")` can't void a question and block its recovery. Recovered records append after saved ones, so a verbatim STT answer can never override a curated one.
- Coach worker opts out of question tagging (`tag_questions=False`) — its chat reuses the interview context but isn't answering the plan.
- Deepgram STT tuning per language tier: nova-3 (en/multi) keeps 25 ms endpointing; nova-2 (vi & other non-English) gets Deepgram's 300 ms silence window to stop fragmenting answers; `numerals` gated to the nova-3 tier (the nova-2 tier fails *silently* with zero transcripts on bad flag combos — the exact vi failure mode debugged live on 2026-06-10).

## Testing

- **Live e2e against the running stack (3 cases)**: 71-word answer with `save_answer` never called → `complete` + real report rendered; 5-word reply → honest "No answers recorded"; silent call → `no_answers`. All passed.
- **Regression suite: 143 → 178 tests**, deterministic, ruff-clean:
  - `test_report_regression.py` — API-level twin of prep → live-result → score → session view (recovery, silent calls, curated-wins, idempotency, status-gate).
  - `test_live.py` — substance-gate boundary (11/12 words), small-talk drop, cursor-following bucketing, trailing-empty `save_answer`, wrap-phase exclusion, adaptive-difficulty integration.
  - `test_worker_livekit.py` — the **real** `_on_shutdown` closure driven via faked livekit seams; transcript-capture tagging; Deepgram kwargs/routing. `importorskip`-guarded (CI installs no livekit extra); validated inside the worker image: 10/10.
  - Supabase seam tests via a fake client; blank-only-answers scoring guard.

## Note for reviewers

The nova-2 vi flag set changed vs the 2026-06-10 live-verified baseline (`smart_format` on, 300 ms endpointing are new). That tier's failure mode is silent zero-transcripts, so one Vietnamese voice smoke call is recommended before merging.