### PR TITLE
feat(ee): add @deepinterview/ee open-core extension seam stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,11 @@ __pycache__/
 .DS_Store
 *.log
 
-# Enterprise (commercial license) — kept out of the OSS repo
+# Enterprise (commercial license) — kept out of the OSS repo.
+# Exception: packages/ee is the open-core seam STUB (inert defaults,
+# Apache-2.0) — tracked in OSS; downstream distributions replace its contents.
 ee/
+!packages/ee/
 
 # Product spec / internal design docs (kept local, not published)
 site/

--- a/packages/ee/README.md
+++ b/packages/ee/README.md
@@ -1,0 +1,18 @@
+# @deepinterview/ee
+
+The **open-core extension seam**. This OSS package ships inert defaults
+(`features.*` all `false`, `edition: "oss"`) under Apache-2.0 — the OSS build
+behaves identically with or without it.
+
+A downstream distribution (e.g. a hosted/commercial edition) maintains its own
+repo and replaces the **contents** of `packages/ee` — same package name, same
+exported surface — with real implementations. pnpm workspace resolution then
+serves that implementation to every importer. No conditional imports, no build
+flags, no edits to OSS files.
+
+Rules for evolving the seam (upstream-first):
+
+1. Hook points are added **here**, in the OSS repo, with inert defaults.
+2. OSS code may import this package unconditionally and must behave identically
+   with the defaults.
+3. Real (non-default) functionality never lands in this stub.

--- a/packages/ee/package.json
+++ b/packages/ee/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@deepinterview/ee",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Open-core extension seam — inert OSS defaults; downstream distributions replace this package's contents.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/ee/src/index.ts
+++ b/packages/ee/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @deepinterview/ee — DeepInterview's open-core extension seam.
+ *
+ * This OSS stub ships inert defaults under Apache-2.0. A downstream
+ * distribution (e.g. a hosted/commercial edition) replaces the CONTENTS of
+ * `packages/ee` in its own repo — same package name, same exported surface —
+ * and pnpm workspace resolution serves that implementation to every importer.
+ * No conditional imports, no build flags, no OSS file edits.
+ *
+ * Rules for evolving this seam (upstream-first):
+ * 1. Hook points are added HERE, in the OSS repo, with inert defaults.
+ * 2. OSS code may import this package unconditionally and must behave
+ *    identically with the defaults (`features.*` all false).
+ * 3. Real (non-default) functionality never lands in this stub.
+ */
+
+/** Switches a distribution can enable. All false in the OSS build. */
+export interface EeFeatures {
+  /** Hosted accounts / SSO. The OSS build runs auth-free. */
+  readonly auth: boolean;
+  /** Premium voice catalogue beyond the bundled OSS voice packs. */
+  readonly premiumVoices: boolean;
+  /** Billing and plan gating. */
+  readonly billing: boolean;
+}
+
+export type Edition = "oss" | "cloud";
+
+/** Which distribution this build is. */
+export const edition: Edition = "oss";
+
+export const features: EeFeatures = Object.freeze({
+  auth: false,
+  premiumVoices: false,
+  billing: false,
+});

--- a/packages/ee/tsconfig.json
+++ b/packages/ee/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src"]
+}

--- a/packages/ee/tsup.config.ts
+++ b/packages/ee/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  target: 'node20',
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,15 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/ee:
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/shared:
     dependencies:
       zod:


### PR DESCRIPTION
## What

New workspace package `packages/ee` (`@deepinterview/ee`) — the open-core extension seam. It exports inert defaults only: `features` (`auth` / `premiumVoices` / `billing`, all `false`) and `edition: "oss"`. Nothing imports it yet, so there is zero behavior change for OSS users.

## Why

DeepInterview is Apache-2.0 open-core. A downstream distribution (e.g. a hosted/commercial edition) tracks this repo and needs a mount point that does not require forking or editing OSS files. With this stub in place, a downstream repo overrides behavior by replacing the *contents* of `packages/ee` — same package name, same exported surface — and pnpm workspace resolution serves that implementation to every importer. No conditional imports, no build flags.

## Notes

- `.gitignore` previously blanket-ignored `ee/` (the enterprise leak-guard). That guard stays; this adds a precise `!packages/ee/` carve-out so only the inert, Apache-2.0 stub is tracked.
- Seam rules (upstream-first): hook points are added here with inert defaults; OSS code may import this package unconditionally and must behave identically with the defaults; real (non-default) functionality never lands in the stub.
- First consumers (auth middleware pass-through, voice-pack registry) arrive with the features that need them.
- `pnpm turbo build typecheck --filter=@deepinterview/ee` passes.