### PR TITLE
feat(ee): add gateRequest auth seam with fail-closed consumers

### DIFF
--- a/apps/web/app/api/coach/chat/route.ts
+++ b/apps/web/app/api/coach/chat/route.ts
@@ -5,7 +5,9 @@ import {
   LanguageSchema,
   type CoachReply,
 } from "@deepinterview/shared";
+import { gateRequest } from "@deepinterview/ee";
 import { serverEnv } from "@/lib/env";
+import { getUser } from "@/lib/supabase/server";
 
 // Reads server-only config (AGENT_API_URL) and proxies a live agent call.
 export const dynamic = "force-dynamic";
@@ -43,6 +45,17 @@ function mockReply(query: string): CoachReply {
 }
 
 export async function POST(request: Request) {
+  // Distribution gate (no-op in OSS): coach replies spend LLM tokens; a
+  // distribution with required auth rejects anonymous callers here.
+  const user = await getUser();
+  const gate = gateRequest({
+    pathname: "/api/coach/chat",
+    isAuthenticated: Boolean(user),
+  });
+  if (!gate.allow) {
+    return NextResponse.json({ error: "Sign in required" }, { status: 401 });
+  }
+
   let body: z.infer<typeof BodySchema>;
   try {
     body = BodySchema.parse(await request.json());

--- a/apps/web/app/api/kb/query/route.ts
+++ b/apps/web/app/api/kb/query/route.ts
@@ -5,6 +5,7 @@ import {
   LanguageSchema,
   type KbQueryResponse,
 } from "@deepinterview/shared";
+import { gateRequest } from "@deepinterview/ee";
 import { getUser } from "@/lib/supabase/server";
 
 // Reads server-only env (LIGHTRAG_URL) and the per-request user; never prerender.
@@ -49,6 +50,18 @@ function mockAnswer(query: string): KbQueryResponse {
 }
 
 export async function POST(request: Request) {
+  // Resolve the user server-side; anonymous when there's no session. The
+  // distribution gate (no-op in OSS) runs before any work — including the
+  // offline mock — so required-auth distributions are consistent here.
+  const user = await getUser();
+  const gate = gateRequest({
+    pathname: "/api/kb/query",
+    isAuthenticated: Boolean(user),
+  });
+  if (!gate.allow) {
+    return NextResponse.json({ error: "Sign in required" }, { status: 401 });
+  }
+
   let body: z.infer<typeof BodySchema>;
   try {
     body = BodySchema.parse(await request.json());
@@ -66,8 +79,6 @@ export async function POST(request: Request) {
     return NextResponse.json(mockAnswer(body.query));
   }
 
-  // Resolve the user server-side; anonymous when there's no session.
-  const user = await getUser();
   const userId = user?.id ?? "anonymous";
 
   try {

--- a/apps/web/app/api/token/route.ts
+++ b/apps/web/app/api/token/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import type { TokenResponse } from "@deepinterview/shared";
+import { gateRequest } from "@deepinterview/ee";
 import { getUser } from "@/lib/supabase/server";
 import { createInterviewToken } from "@/lib/livekit";
 import { isLiveKitConfigured, isSupabaseConfigured } from "@/lib/env";
@@ -22,11 +23,23 @@ export async function POST(request: Request) {
   }
 
   // Auth: require a user when Supabase is configured; allow a dev identity offline.
+  const user = isSupabaseConfigured() ? await getUser() : null;
+
+  // Distribution gate (no-op in OSS): LiveKit tokens grant publish time; a
+  // required-auth distribution rejects anonymous callers here even when the
+  // Supabase env is missing/broken (fail closed).
+  const gate = gateRequest({
+    pathname: "/api/token",
+    isAuthenticated: Boolean(user),
+  });
+  if (!gate.allow) {
+    return NextResponse.json({ error: "Sign in required" }, { status: 401 });
+  }
+
   let identity = body.identity;
   let name: string | undefined;
 
   if (isSupabaseConfigured()) {
-    const user = await getUser();
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { gateRequest } from "@deepinterview/ee";
 import { presignUpload } from "@/lib/r2";
 import { isR2Configured } from "@/lib/env";
+import { getUser } from "@/lib/supabase/server";
 
 const BodySchema = z.object({
   filename: z.string().min(1),
@@ -9,6 +11,17 @@ const BodySchema = z.object({
 });
 
 export async function POST(request: Request) {
+  // Distribution gate (no-op in OSS): presigned uploads cost storage; a
+  // distribution with required auth rejects anonymous callers here.
+  const user = await getUser();
+  const gate = gateRequest({
+    pathname: "/api/upload",
+    isAuthenticated: Boolean(user),
+  });
+  if (!gate.allow) {
+    return NextResponse.json({ error: "Sign in required" }, { status: 401 });
+  }
+
   let body: z.infer<typeof BodySchema>;
   try {
     body = BodySchema.parse(await request.json());

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -19,6 +19,23 @@ import { Label } from "@/components/ui/label";
 import { Eyebrow } from "@/components/ui/eyebrow";
 import { Spinner } from "@/components/ui/spinner";
 
+/**
+ * Post-login destination. Resolve the candidate against a sentinel origin and
+ * require it to stay there — this rejects absolute URLs, protocol-relative
+ * `//host`, and the URL parser's backslash / control-character normalization
+ * tricks (`/\evil.com`, `/%09/evil.com`) that prefix checks miss.
+ */
+function safeNext(raw: string | null): string {
+  if (!raw || !raw.startsWith("/")) return "/setup";
+  try {
+    const resolved = new URL(raw, "http://internal");
+    if (resolved.origin !== "http://internal") return "/setup";
+    return resolved.pathname + resolved.search + resolved.hash;
+  } catch {
+    return "/setup";
+  }
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const messages = useMessages();
@@ -45,7 +62,11 @@ export default function LoginPage() {
       setBusy(false);
       return;
     }
-    router.push("/setup");
+    // Read ?next= at submit time (client event) — avoids useSearchParams,
+    // which would force the prerendered page into a blank Suspense shell.
+    router.push(
+      safeNext(new URLSearchParams(window.location.search).get("next")),
+    );
   }
 
   return (

--- a/apps/web/app/setup/actions.ts
+++ b/apps/web/app/setup/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import type { PrepRequest } from "@deepinterview/shared";
+import { features } from "@deepinterview/ee";
 import { requestPrep } from "@/lib/api";
 import { createClient, getUser } from "@/lib/supabase/server";
 import { isSupabaseConfigured } from "@/lib/env";
@@ -13,8 +14,13 @@ import {
 export type StartSessionResult =
   | { ok: true; session_id: string }
   // `error` stays required (existing consumers read `result.error`); `reason`
-  // is an additive discriminator the client uses to route to /pricing.
-  | { ok: false; error: string; reason?: "out_of_interviews" };
+  // is an additive discriminator the client uses to route to /pricing
+  // (out_of_interviews) or /login (auth_required).
+  | {
+      ok: false;
+      error: string;
+      reason?: "out_of_interviews" | "auth_required";
+    };
 
 /**
  * Kick off the prep pipeline and return the new session id. We return
@@ -47,31 +53,44 @@ export async function startSession(
       userId = user.id;
       supabase = await createClient();
     }
+  }
 
-    // Load the billing-relevant profile row and roll the monthly period if due.
-    if (supabase) {
-      await supabase.rpc("reset_usage_if_due", { p_user_id: userId });
-      const { data } = await supabase
-        .from("profiles")
-        .select("plan, interviews_used, credits")
-        .eq("id", userId)
-        .maybeSingle();
-      profile = (data as ProfileBilling | null) ?? {
-        plan: "free",
-        interviews_used: 0,
-        credits: 0,
+  if (!userId && features.auth) {
+    // Distribution gate (no-op in OSS): server actions are public POST
+    // endpoints, so a required-auth distribution must fail closed here even
+    // though its proxy already redirects anonymous visitors off /setup.
+    // Deliberately OUTSIDE the `configured` branch: a missing/broken Supabase
+    // env must never let anonymous callers create sessions in such a build.
+    return {
+      ok: false,
+      error: "Sign in to start an interview.",
+      reason: "auth_required",
+    };
+  }
+
+  // Load the billing-relevant profile row and roll the monthly period if due.
+  if (supabase) {
+    await supabase.rpc("reset_usage_if_due", { p_user_id: userId });
+    const { data } = await supabase
+      .from("profiles")
+      .select("plan, interviews_used, credits")
+      .eq("id", userId)
+      .maybeSingle();
+    profile = (data as ProfileBilling | null) ?? {
+      plan: "free",
+      interviews_used: 0,
+      credits: 0,
+    };
+
+    // GOLDEN RULE 5: enforce the cap before any interview is created.
+    const gate = canStartInterview(profile);
+    if (!gate.allowed) {
+      return {
+        ok: false,
+        error:
+          "You've used all your interviews for this period. Upgrade or buy credits to continue.",
+        reason: gate.reason,
       };
-
-      // GOLDEN RULE 5: enforce the cap before any interview is created.
-      const gate = canStartInterview(profile);
-      if (!gate.allowed) {
-        return {
-          ok: false,
-          error:
-            "You've used all your interviews for this period. Upgrade or buy credits to continue.",
-          reason: gate.reason,
-        };
-      }
     }
   }
 

--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { features } from "@deepinterview/ee";
 import { Container } from "@/components/ui/container";
 import { buttonClasses } from "@/components/ui/button";
 import { MobileMenu } from "@/components/landing/mobile-menu";
@@ -41,10 +42,24 @@ export function Nav() {
           >
             GitHub
           </a>
+          {features.auth ? (
+            <Link
+              href="/login"
+              className="hidden text-[14.5px] text-ink-soft hover:text-ink min-[861px]:inline"
+            >
+              Sign in
+            </Link>
+          ) : null}
           <Link href="/setup" className={buttonClasses()}>
             Start free
           </Link>
-          <MobileMenu links={NAV_LINKS} />
+          <MobileMenu
+            links={
+              features.auth
+                ? [...NAV_LINKS, { href: "/login", label: "Sign in" }]
+                : NAV_LINKS
+            }
+          />
         </div>
       </Container>
     </nav>

--- a/apps/web/components/setup/setup-form.tsx
+++ b/apps/web/components/setup/setup-form.tsx
@@ -226,6 +226,12 @@ export function SetupForm({ r2Configured }: { r2Configured: boolean }) {
           router.push("/pricing");
           return;
         }
+        // Required-auth distribution and the session expired mid-form →
+        // sign back in, then return to setup.
+        if (result.reason === "auth_required") {
+          router.push("/login?next=/setup");
+          return;
+        }
         setError(result.error);
         setSubmitting(false);
         return;

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient } from "@supabase/ssr";
+import { gateRequest } from "@deepinterview/ee";
 import { isSupabaseConfigured, publicEnv } from "@/lib/env";
 
 type CookieToSet = {
@@ -9,42 +10,62 @@ type CookieToSet = {
 };
 
 /**
- * Refresh the Supabase auth session cookie on every matched request.
+ * Refresh the Supabase auth session cookie on every matched request, then
+ * consult the distribution gate (no-op in OSS).
  *
- * When Supabase is not configured this is a no-op pass-through, so the app
- * still serves requests offline. Do NOT insert logic between `createServerClient`
- * and `auth.getUser()` — the cookie refresh depends on that ordering.
+ * When Supabase is not configured the refresh is skipped, but the gate still
+ * runs with `isAuthenticated: false` — a required-auth distribution must fail
+ * CLOSED on missing/broken env, not silently serve everything. Do NOT insert
+ * logic between `createServerClient` and `auth.getUser()` — the cookie
+ * refresh depends on that ordering.
  */
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
+  let isAuthenticated = false;
 
-  if (!isSupabaseConfigured()) {
-    return supabaseResponse;
-  }
-
-  const supabase = createServerClient(
-    publicEnv.supabaseUrl as string,
-    publicEnv.supabaseAnonKey as string,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet: CookieToSet[]) {
-          cookiesToSet.forEach(({ name, value }) =>
-            request.cookies.set(name, value),
-          );
-          supabaseResponse = NextResponse.next({ request });
-          cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options),
-          );
+  if (isSupabaseConfigured()) {
+    const supabase = createServerClient(
+      publicEnv.supabaseUrl as string,
+      publicEnv.supabaseAnonKey as string,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll();
+          },
+          setAll(cookiesToSet: CookieToSet[]) {
+            cookiesToSet.forEach(({ name, value }) =>
+              request.cookies.set(name, value),
+            );
+            supabaseResponse = NextResponse.next({ request });
+            cookiesToSet.forEach(({ name, value, options }) =>
+              supabaseResponse.cookies.set(name, value, options),
+            );
+          },
         },
       },
-    },
-  );
+    );
 
-  // IMPORTANT: keep this immediately after client creation; refreshes the token.
-  await supabase.auth.getUser();
+    // IMPORTANT: keep this immediately after client creation; refreshes the token.
+    const { data } = await supabase.auth.getUser();
+    isAuthenticated = Boolean(data.user);
+  }
+
+  // Distribution gate (no-op in OSS): pages only — API routes self-gate with
+  // 401s in their handlers, a redirect-to-login is the wrong shape for them.
+  const pathname = request.nextUrl.pathname;
+  if (!pathname.startsWith("/api/")) {
+    const gate = gateRequest({ pathname, isAuthenticated });
+    if (!gate.allow) {
+      const redirectResponse = NextResponse.redirect(
+        new URL(gate.redirectTo ?? "/login", request.url),
+      );
+      // Carry any refreshed auth cookies over to the redirect.
+      for (const cookie of supabaseResponse.cookies.getAll()) {
+        redirectResponse.cookies.set(cookie);
+      }
+      return redirectResponse;
+    }
+  }
 
   return supabaseResponse;
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1063.0",
     "@aws-sdk/s3-request-presigner": "^3.1063.0",
+    "@deepinterview/ee": "workspace:*",
     "@deepinterview/shared": "workspace:*",
     "@livekit/components-react": "^2.9.21",
     "@livekit/components-styles": "^1.2.0",

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -14,10 +14,16 @@ export const config = {
      * - _next/static (build assets)
      * - _next/image (image optimizer)
      * - favicon.ico
-     * - API routes that never read auth cookies, where a refresh per request
-     *   is pure waste — api/session is polled every ~1.2s by the prep screen:
+     * - API routes where a proxy refresh per request is pure waste —
+     *   api/session is polled every ~1.2s by the prep screen and reads no
+     *   auth; api/coach + api/upload resolve the user in-handler (route
+     *   handlers can write cookies, so supabase-js refreshes the session
+     *   itself) and self-gate via @deepinterview/ee; api/health and
+     *   api/billing/webhook are identity-free:
      *   api/health, api/session, api/coach, api/upload, api/billing/webhook.
-     * API routes that DO read auth cookies (api/token, api/kb) stay matched.
+     * API routes that rely on the proxy refresh (api/token, api/kb) stay
+     * matched. The distribution gate in updateSession applies to pages only;
+     * API handlers self-gate with 401s.
      */
     "/((?!_next/static|_next/image|favicon.ico|api/health|api/session|api/coach|api/upload|api/billing/webhook).*)",
   ],

--- a/packages/ee/src/index.ts
+++ b/packages/ee/src/index.ts
@@ -34,3 +34,29 @@ export const features: EeFeatures = Object.freeze({
   premiumVoices: false,
   billing: false,
 });
+
+/** Input to {@link gateRequest}: one request's identity-relevant facts. */
+export interface GateInput {
+  /** Request pathname, e.g. "/setup" or "/api/upload". */
+  readonly pathname: string;
+  /** Whether the request carries a signed-in user. */
+  readonly isAuthenticated: boolean;
+}
+
+export type GateResult =
+  | { readonly allow: true }
+  | { readonly allow: false; readonly redirectTo?: string };
+
+/**
+ * Access decision for a request. Consumers:
+ * - the web proxy (page navigations) redirects to `redirectTo` on deny;
+ * - cost-bearing route handlers (/api/upload, /api/coach/chat, /api/kb/query)
+ *   respond 401 on deny and ignore `redirectTo`.
+ *
+ * The OSS build allows everything (auth stays optional / self-host friendly).
+ * A distribution that flips `features.auth` decides here which paths require
+ * a signed-in user.
+ */
+export function gateRequest(_input: GateInput): GateResult {
+  return { allow: true };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1063.0
         version: 3.1063.0
+      '@deepinterview/ee':
+        specifier: workspace:*
+        version: link:../../packages/ee
       '@deepinterview/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## What

Extends the `@deepinterview/ee` seam with one hook — `gateRequest({pathname, isAuthenticated}) → {allow} | {allow:false, redirectTo}` (the OSS stub always allows) — and wires its consumers:

- **Pages**: the supabase session proxy (`lib/supabase/middleware.ts`) consults the gate after the token refresh and redirects on deny, carrying refreshed auth cookies. The gate runs even when Supabase is unconfigured, so a required-auth distribution fails **closed** on missing/broken env.
- **Cost-bearing APIs**: `/api/upload`, `/api/coach/chat`, `/api/kb/query`, `/api/token` consult the gate in-handler and return 401 on deny.
- **`startSession` server action**: fails closed with `reason: "auth_required"` for anonymous callers in a required-auth build (server actions are public POST endpoints); the setup form routes that to `/login?next=/setup`.
- **Nav**: shows a "Sign in" link when `features.auth` (static check — landing stays statically renderable).
- **`/login`**: honors a validated `?next=` (read at submit time from `location.search`, so the page keeps its prerendered form — no Suspense shell). Validation resolves the candidate against a sentinel origin, rejecting absolute URLs, `//host`, and the URL parser's backslash/control-char tricks (`/\evil.com`, `/%09/evil.com`).

## OSS behavior

Identical with the stub: gate always allows, `features.auth` is false, the only additions on hot paths are inert function calls. Optional auth stays optional for self-hosters.

## Notes

- Adversarially reviewed pre-push (security / OSS-regression / Next 16 lenses); the open-redirect vectors and a fail-open-on-missing-env coupling were found and fixed in this diff.
- `pnpm gen:schema && build && typecheck && lint && test` all pass; schema unchanged.