### PR TITLE
fix(prep): recover the real question plan when Gemini appends trailing JSON

### DIFF
--- a/apps/agent/src/deepinterview_agent/core/adapters/llm.py
+++ b/apps/agent/src/deepinterview_agent/core/adapters/llm.py
@@ -42,17 +42,41 @@ def _schema_prompt(system: str, schema: type) -> str:
 
 
 def _loads_json(text: str) -> Any:
-    """Parse JSON from an LLM response, tolerating ```json fences / stray prose."""
+    """Parse JSON from an LLM response, tolerating ```json fences, stray prose, and
+    *trailing* "Extra data".
+
+    The keystone failure this fixes: the question planner has the largest schema,
+    so its real Gemini response is the biggest — and a complete JSON object was
+    sometimes FOLLOWED by extra content (a second object / trailing commentary).
+    Plain ``json.loads`` raises ``Extra data`` on that, and the old greedy
+    ``\\{.*\\}`` fallback spanned to the LAST brace (swallowing the trailing junk
+    into invalid JSON), so every plan silently fell back to the generic mock —
+    an interview that asks one question literally titled "mock". ``raw_decode``
+    returns the FIRST complete JSON value and ignores anything after it.
+    """
+    import re  # noqa: PLC0415
+
     t = (text or "").strip()
+    # Strip a wrapping ```json ... ``` / ``` ... ``` markdown fence, if present.
+    if t.startswith("```"):
+        t = re.sub(r"^```[^\n]*\n?", "", t)
+        t = re.sub(r"\n?```\s*$", "", t).strip()
+    # Fast path: a single clean JSON value.
     try:
         return json.loads(t)
     except json.JSONDecodeError:
-        import re  # noqa: PLC0415
-
-        m = re.search(r"\{.*\}|\[.*\]", t, re.DOTALL)
-        if m:
-            return json.loads(m.group(0))
-        raise
+        pass
+    # Tolerant path: decode the first complete JSON value starting at the first
+    # '{' or '[', ignoring any trailing data (raw_decode is "Extra data"-safe).
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(t):
+        if ch in "{[":
+            try:
+                obj, _end = decoder.raw_decode(t, i)
+                return obj
+            except json.JSONDecodeError:
+                continue
+    raise json.JSONDecodeError("no JSON value found in LLM response", t, 0)
 
 
 class GeminiLLM:

--- a/apps/agent/tests/test_llm_json.py
+++ b/apps/agent/tests/test_llm_json.py
@@ -1,0 +1,47 @@
+"""Regression tests for the real-LLM JSON response parser (no SDK / API key).
+
+Pins the production bug found by the full-stack real-provider e2e: the question
+planner — the largest schema, so the biggest real Gemini response — returned a
+valid JSON object FOLLOWED BY extra data, which the old ``json.loads`` + greedy
+``{.*}`` fallback rejected, silently falling back to the generic mock plan (every
+interview asked one question titled "mock"). These tests run on the deterministic
+mock plan shape, so they catch a regression in CI without any provider key.
+"""
+
+from __future__ import annotations
+
+from deepinterview_agent.core.adapters.llm import _loads_json
+from deepinterview_agent.core.adapters.mock import build_mock
+from deepinterview_agent.shared_models import QuestionPlan
+
+
+def test_loads_clean_object() -> None:
+    assert _loads_json('{"a": 1}') == {"a": 1}
+
+
+def test_loads_clean_array() -> None:
+    assert _loads_json('[1, 2, 3]') == [1, 2, 3]
+
+
+def test_loads_strips_json_fence() -> None:
+    assert _loads_json('```json\n{"a": 1}\n```') == {"a": 1}
+    assert _loads_json('```\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_loads_first_value_when_trailing_extra_data() -> None:
+    """THE failure class: a complete object, then 'Extra data' json.loads rejects."""
+    assert _loads_json('{"a": 1}\n{"b": 2}') == {"a": 1}
+    assert _loads_json('{"a": 1}\n\nNote: hope this helps!') == {"a": 1}
+
+
+def test_loads_object_after_leading_prose() -> None:
+    assert _loads_json('Here is your JSON:\n{"a": 1}') == {"a": 1}
+
+
+def test_question_plan_survives_trailing_extra_data() -> None:
+    """A realistic QuestionPlan payload with a duplicate trailing object still
+    validates to the FIRST (complete) plan — not a mock fallback."""
+    plan = build_mock(QuestionPlan)
+    payload = plan.model_dump_json() + '\n\n{"note": "duplicate emission"}'
+    parsed = QuestionPlan.model_validate(_loads_json(payload))
+    assert parsed.model_dump() == plan.model_dump()


### PR DESCRIPTION
## Problem

The full-stack real-provider e2e (prep → score against the dockerized `agent-api` with real Gemini/Tavily keys) surfaced a keystone bug: **every node used real Gemini except the question planner**, which fell back to the mock plan — so a real interview asked a single question whose text was literally `"mock"`.

Root cause, from the agent-api logs:

```
WARNING question_planner failed, using minimal generic plan (Extra data: line 138 column 1 (char 5330))
```

`QuestionPlan` is the largest schema, so its real Gemini response is the biggest — and a complete JSON object was sometimes followed by **"Extra data"** (a trailing object / commentary). `_loads_json`'s `json.loads` raised on that, and the greedy `{.*}` fallback spanned to the *last* brace, folding the trailing junk into invalid JSON. Result: the keystone planner silently degraded to the generic mock for every real run.

## Fix

- `core/adapters/llm.py::_loads_json` now decodes the **first complete JSON value** with `JSONDecoder().raw_decode` (ignoring trailing data) and strips ```` ```json ```` fences.
- New **key-free** regression suite `tests/test_llm_json.py` reproducing the Extra-data shape (incl. a realistic `QuestionPlan` payload with a trailing duplicate object). Mock-only CI could not catch this — only the largest schema produces a response big enough to attract trailing content.

## Verification

Re-ran the e2e after the fix → **9/9 green**, `real_providers: true`, zero mock markers. The planner now produces tailored questions, e.g.:

> *At Stripe's scale, ledger consistency is paramount — walk me through how you've designed systems to ensure consistency across distributed transactions during partial-failure modes in an event-driven architecture.*

> *Implement a robust parser for a payment notification string (e.g. `TXN_123:SUCCESS:89.99:USD`)… write a test case first (TDD).*

- `184 passed` (178 baseline + 6 new)
- `ruff check` clean on the changed files