### PR TITLE
feat(cli): real `deepinterview init` key wizard (the adoption lever)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,14 +11,17 @@
   ],
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@clack/prompts": "^0.11.0",
     "@deepinterview/shared": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
     "tsup": "^8.5.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,6 +1,19 @@
-import { existsSync, copyFileSync } from "node:fs";
+import { existsSync, copyFileSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
+import {
+  intro,
+  outro,
+  select,
+  text,
+  password,
+  confirm,
+  isCancel,
+  cancel,
+  note,
+  log,
+} from "@clack/prompts";
 import { LANGUAGES } from "@deepinterview/shared";
+import { parseEnv, renderEnv } from "../lib/env-template";
 
 function findRepoRoot(start: string): string {
   let dir = start;
@@ -13,15 +26,314 @@ function findRepoRoot(start: string): string {
   return start;
 }
 
+/** Show a secret as ••••last4 — never echo a key back in full. */
+function mask(value: string): string {
+  if (!value) return "(empty)";
+  return value.length <= 4 ? "••••" : `••••${value.slice(-4)}`;
+}
+
+function isSecretKey(key: string): boolean {
+  return /(KEY|SECRET|TOKEN)/.test(key) && !key.endsWith("_PROVIDER");
+}
+
+/** Abort cleanly when the user hits Ctrl-C / Esc at any prompt. */
+function ensure<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Setup cancelled — no files were written.");
+    process.exit(0);
+  }
+  return value as T;
+}
+
+/** Ask for a secret, offering to keep an already-configured value. */
+async function secret(
+  label: string,
+  existing: string | undefined,
+): Promise<string> {
+  if (existing) {
+    const keep = ensure(
+      await confirm({
+        message: `${label} is already set (${mask(existing)}). Keep it?`,
+        initialValue: true,
+      }),
+    );
+    if (keep) return existing;
+  }
+  const value = ensure(
+    await password({
+      message: `${label}${existing ? " — new value" : " (leave blank to skip)"}`,
+    }),
+  );
+  return value ?? "";
+}
+
+/** Ask for a plain (non-secret) value, prefilled with any existing one. */
+async function field(
+  label: string,
+  existing: string | undefined,
+  placeholder = "",
+): Promise<string> {
+  const value = ensure(
+    await text({ message: label, placeholder, initialValue: existing ?? "" }),
+  );
+  return (value ?? "").trim();
+}
+
+type Values = Record<string, string>;
+
+async function collectLlm(existing: Values, values: Values): Promise<void> {
+  const provider = ensure(
+    await select({
+      message: "LLM provider (prep questions, scoring, live answers)",
+      initialValue: existing.LLM_PROVIDER || "gemini",
+      options: [
+        { value: "gemini", label: "Google Gemini", hint: "default" },
+        { value: "openai", label: "OpenAI" },
+        { value: "mock", label: "Mock — offline, no key" },
+      ],
+    }),
+  );
+  values.LLM_PROVIDER = provider;
+  if (provider === "gemini") {
+    values.GEMINI_API_KEY = await secret(
+      "Gemini API key",
+      existing.GEMINI_API_KEY,
+    );
+  } else if (provider === "openai") {
+    values.OPENAI_API_KEY = await secret(
+      "OpenAI API key",
+      existing.OPENAI_API_KEY,
+    );
+  }
+}
+
+async function collectStt(existing: Values, values: Values): Promise<void> {
+  const provider = ensure(
+    await select({
+      message: "Speech-to-text provider",
+      initialValue: existing.STT_PROVIDER || "deepgram",
+      options: [
+        {
+          value: "deepgram",
+          label: "Deepgram",
+          hint: "nova-3, the tested path",
+        },
+        { value: "soniox", label: "Soniox" },
+      ],
+    }),
+  );
+  values.STT_PROVIDER = provider;
+  const key = provider === "deepgram" ? "DEEPGRAM_API_KEY" : "SONIOX_API_KEY";
+  values[key] = await secret(`${provider} API key`, existing[key]);
+}
+
+async function collectTts(existing: Values, values: Values): Promise<void> {
+  const provider = ensure(
+    await select({
+      message: "Text-to-speech provider",
+      initialValue: existing.TTS_PROVIDER || "cartesia",
+      options: [
+        { value: "cartesia", label: "Cartesia", hint: "default" },
+        { value: "elevenlabs", label: "ElevenLabs" },
+      ],
+    }),
+  );
+  values.TTS_PROVIDER = provider;
+  const key =
+    provider === "cartesia" ? "CARTESIA_API_KEY" : "ELEVENLABS_API_KEY";
+  values[key] = await secret(`${provider} API key`, existing[key]);
+}
+
+async function collectLiveKit(existing: Values, values: Values): Promise<void> {
+  values.LIVEKIT_URL = await field(
+    "LiveKit URL (wss://your-project.livekit.cloud)",
+    existing.LIVEKIT_URL,
+    "wss://…",
+  );
+  values.LIVEKIT_API_KEY = await secret(
+    "LiveKit API key",
+    existing.LIVEKIT_API_KEY,
+  );
+  values.LIVEKIT_API_SECRET = await secret(
+    "LiveKit API secret",
+    existing.LIVEKIT_API_SECRET,
+  );
+}
+
+async function collectSearch(existing: Values, values: Values): Promise<void> {
+  const provider = ensure(
+    await select({
+      message: "Company research (web search for interview intel)",
+      initialValue: existing.SEARCH_PROVIDER || "tavily",
+      options: [
+        { value: "tavily", label: "Tavily" },
+        { value: "exa", label: "Exa" },
+        { value: "mock", label: "Mock — offline, no real research" },
+      ],
+    }),
+  );
+  values.SEARCH_PROVIDER = provider;
+  if (provider === "tavily") {
+    values.TAVILY_API_KEY = await secret(
+      "Tavily API key",
+      existing.TAVILY_API_KEY,
+    );
+  } else if (provider === "exa") {
+    values.EXA_API_KEY = await secret("Exa API key", existing.EXA_API_KEY);
+  }
+}
+
+async function collectSupabase(
+  existing: Values,
+  values: Values,
+): Promise<void> {
+  const use = ensure(
+    await confirm({
+      message:
+        "Configure Supabase (sign-in, file storage, saved reports)? The OSS app runs fine without it.",
+      initialValue: Boolean(existing.SUPABASE_URL),
+    }),
+  );
+  if (!use) return;
+  const url = await field(
+    "Supabase project URL (https://xxxx.supabase.co)",
+    existing.SUPABASE_URL,
+    "https://…supabase.co",
+  );
+  values.SUPABASE_URL = url;
+  // The browser auth client reads the NEXT_PUBLIC_-prefixed name; it's the same URL.
+  values.NEXT_PUBLIC_SUPABASE_URL = url;
+  values.SUPABASE_SERVICE_ROLE_KEY = await secret(
+    "Supabase service-role key",
+    existing.SUPABASE_SERVICE_ROLE_KEY,
+  );
+  values.NEXT_PUBLIC_SUPABASE_ANON_KEY = await secret(
+    "Supabase anon (public) key",
+    existing.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  );
+}
+
+async function runWizard(existing: Values): Promise<Values> {
+  const values: Values = {};
+  const mode = ensure(
+    await select({
+      message: "What do you want to run?",
+      options: [
+        {
+          value: "voice",
+          label: "Live voice interview",
+          hint: "real STT + AI + TTS + LiveKit",
+        },
+        {
+          value: "prep",
+          label: "Prep + scoring only",
+          hint: "real AI, no microphone",
+        },
+        {
+          value: "offline",
+          label: "Offline demo",
+          hint: "zero keys — mock providers",
+        },
+      ],
+    }),
+  );
+
+  if (mode === "offline") {
+    values.LLM_PROVIDER = "mock";
+    values.SEARCH_PROVIDER = "mock";
+    note(
+      "The full stack runs on deterministic mock providers — no keys needed.\nThe live voice worker is not used in this mode.",
+      "Offline demo",
+    );
+    return values;
+  }
+
+  await collectLlm(existing, values);
+  if (mode === "voice") {
+    await collectStt(existing, values);
+    await collectTts(existing, values);
+    await collectLiveKit(existing, values);
+  }
+  await collectSearch(existing, values);
+  await collectSupabase(existing, values);
+  return values;
+}
+
+function summarize(values: Values): string {
+  return Object.keys(values)
+    .map((key) => {
+      const value = values[key] ?? "";
+      const shown = isSecretKey(key) ? mask(value) : value || "(empty)";
+      return `${key}=${shown}`;
+    })
+    .join("\n");
+}
+
+/** Overwrite an app-local copy from the freshly written root .env. */
+function writeAppCopy(source: string, target: string, root: string): void {
+  const label = relative(root, target);
+  if (!existsSync(dirname(target))) {
+    log.warn(`Skipped ${label} (directory not found)`);
+    return;
+  }
+  copyFileSync(source, target);
+  log.success(`Synced ${label}`);
+}
+
+function nextSteps(values: Values): string {
+  const lines = [
+    "Next steps:",
+    "  docker compose up            # full stack with the keys you just set",
+    "  (or) pnpm dev                # web :3000 + agent API :8000",
+  ];
+  if (values.STT_PROVIDER || values.LIVEKIT_URL) {
+    lines.push(
+      "  docker compose --profile live up   # add the live voice worker",
+    );
+  }
+  lines.push(
+    "",
+    "Re-run `deepinterview init` anytime — existing values are offered as defaults.",
+  );
+  return lines.join("\n");
+}
+
 /**
- * Mirror the root .env into an app-local copy. Local dev (`pnpm dev`) never
- * reads the root .env: the Python agent loads apps/agent/.env
- * (pydantic-settings, cwd-relative) and Next.js loads apps/web/.env.local —
- * so without these copies the wizard's output is dead config for local dev.
- *
- * Same semantics as the root file: create only when missing, overwrite with
- * --force. Skips quietly (with a note) when the app directory doesn't exist.
+ * Non-interactive fallback (CI, piped stdin, `--no-input`): keep the original
+ * copy-from-template behaviour so scripted setups and the local-dev copies still
+ * work without a TTY. The interactive key wizard runs only on a real terminal.
  */
+function runNonInteractive(
+  root: string,
+  example: string,
+  target: string,
+  force: boolean,
+): void {
+  if (existsSync(target) && !force) {
+    console.error(
+      ".env already exists — re-run with --force to re-sync the local-dev " +
+        "copies (apps/agent/.env, apps/web/.env.local), or run `deepinterview " +
+        "init` in a terminal for the interactive key wizard.",
+    );
+    process.exit(1);
+  }
+  if (!existsSync(target)) {
+    copyFileSync(example, target);
+    console.log(
+      `✓ Wrote ${target} from .env.example (non-interactive). Fill in keys, or ` +
+        "run `deepinterview init` in a terminal for the guided wizard.",
+    );
+  } else {
+    console.log(`✓ Kept ${target} (sync source — your keys are preserved)`);
+  }
+  syncCopy(target, join(root, "apps", "agent", ".env"), root, force);
+  syncCopy(target, join(root, "apps", "web", ".env.local"), root, force);
+  console.log(
+    `\nDeepInterview supports ${LANGUAGES.length} languages (English-first).`,
+  );
+}
+
+/** Copy the root .env into an app-local copy (create-if-missing; --force to overwrite). */
 function syncCopy(
   source: string,
   target: string,
@@ -43,6 +355,7 @@ function syncCopy(
 
 export async function runInit(args: string[]): Promise<void> {
   const force = args.includes("--force");
+  const noInput = args.includes("--no-input") || args.includes("--yes");
   const root = findRepoRoot(process.cwd());
   const example = join(root, ".env.example");
   const target = join(root, ".env");
@@ -51,41 +364,43 @@ export async function runInit(args: string[]): Promise<void> {
     console.error(`Could not find .env.example near ${root}`);
     process.exit(1);
   }
-  if (existsSync(target) && !force) {
-    console.error(
-      ".env already exists — re-run with --force to re-sync the local-dev " +
-        "copies from it (apps/agent/.env, apps/web/.env.local).",
+
+  const interactive = Boolean(process.stdin.isTTY) && !noInput;
+  if (!interactive) {
+    runNonInteractive(root, example, target, force);
+    return;
+  }
+
+  const template = readFileSync(example, "utf8");
+  const existing = existsSync(target)
+    ? parseEnv(readFileSync(target, "utf8"))
+    : {};
+
+  intro("DeepInterview setup");
+  if (Object.keys(existing).length > 0) {
+    log.info(
+      "Found an existing .env — current values are offered as defaults.",
     );
-    process.exit(1);
   }
 
-  if (!existsSync(target)) {
-    copyFileSync(example, target);
-    console.log(`✓ Wrote ${target} from .env.example`);
-  } else {
-    // --force with an existing root .env: keep it — it holds the user's keys
-    // and is the single place to edit. --force means "re-sync the local-dev
-    // copies from the root .env", NOT "reset my keys from the template".
-    // To start over from the template, delete .env and re-run init.
-    console.log(`✓ Kept ${target} (sync source — your keys are preserved)`);
-  }
-
-  // Local-dev copies (see syncCopy docstring).
-  syncCopy(target, join(root, "apps", "agent", ".env"), root, force);
-  syncCopy(target, join(root, "apps", "web", ".env.local"), root, force);
-
-  console.log(
-    `DeepInterview supports ${LANGUAGES.length} languages (English-first).`,
+  const values = await runWizard(existing);
+  note(summarize(values), "Will write to .env");
+  const go = ensure(
+    await confirm({
+      message: "Write .env and sync the local-dev copies?",
+      initialValue: true,
+    }),
   );
-  console.log(`
-How the files are used:
-  .env                 → docker compose (the full stack)
-  apps/agent/.env      → local dev: the Python agent (pnpm dev)
-  apps/web/.env.local  → local dev: the Next.js app (pnpm dev)
+  if (!go) {
+    cancel("Nothing written.");
+    process.exit(0);
+  }
 
-Edit your provider keys in the ROOT .env only, then re-run
-\`deepinterview init --force\` to re-sync the local-dev copies.
-WARNING: --force OVERWRITES apps/agent/.env and apps/web/.env.local —
-any edits made directly to those copies are lost (the root .env is kept).
-(Interactive wizard: coming soon.)`);
+  const merged = { ...existing, ...values };
+  writeFileSync(target, `${renderEnv(template, merged)}\n`);
+  log.success(`Wrote ${relative(root, target)}`);
+  writeAppCopy(target, join(root, "apps", "agent", ".env"), root);
+  writeAppCopy(target, join(root, "apps", "web", ".env.local"), root);
+
+  outro(nextSteps(values));
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,21 +6,22 @@ function printHelp(): void {
   console.log(`deepinterview — DeepInterview CLI
 
 Usage:
-  deepinterview init [--force]   Create .env from .env.example and sync the
-                                 local-dev copies
+  deepinterview init             Guided setup: pick a run mode, enter provider
+                                 keys, and write the .env files
+  deepinterview init --no-input  Non-interactive: copy .env.example → .env
+                                 (for CI / scripted setups; --yes is an alias)
+  deepinterview init --force     Re-sync the local-dev copies from the root .env
+                                 (non-interactive)
 
 \`init\` writes three files:
   .env                 → read by docker compose (the full stack)
   apps/agent/.env      → read by the Python agent in local dev (pnpm dev)
   apps/web/.env.local  → read by the Next.js app in local dev (pnpm dev)
 
-Edit your provider keys in the ROOT .env only, then re-run
-\`deepinterview init --force\` to re-sync the local-dev copies.
-WARNING: --force OVERWRITES apps/agent/.env and apps/web/.env.local with the
-root .env (direct edits to the copies are lost; the root .env is kept).
-
-The interactive provider-key wizard arrives in a later milestone; for now
-\`init\` copies .env.example so you can fill in keys by hand.`);
+In a terminal, \`init\` runs an interactive wizard: choose a run mode (live voice
+/ prep-only / offline demo), then enter only the keys that mode needs (existing
+values are offered as defaults, so re-running to update a key is safe). With no
+TTY it falls back to copying .env.example so you can fill in keys by hand.`);
 }
 
 async function main(): Promise<void> {

--- a/cli/src/lib/env-template.test.ts
+++ b/cli/src/lib/env-template.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { parseEnv, formatValue, renderEnv } from "./env-template";
+
+const TEMPLATE = `# Comment header
+NODE_ENV=development
+
+# ── LLM ──
+LLM_PROVIDER=gemini
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+
+# A commented example must be left untouched:
+# EXAMPLE_KEY=do-not-edit
+SEARCH_PROVIDER=mock
+`;
+
+describe("parseEnv", () => {
+  it("reads KEY=VALUE pairs and skips comments / blanks / malformed lines", () => {
+    const parsed = parseEnv(
+      [
+        "# c",
+        "",
+        "LLM_PROVIDER=gemini",
+        "GEMINI_API_KEY=abc123",
+        "junk-line",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      LLM_PROVIDER: "gemini",
+      GEMINI_API_KEY: "abc123",
+    });
+  });
+
+  it("strips surrounding quotes from values", () => {
+    expect(parseEnv("A=\"has spaces\"\nB='x'")).toEqual({
+      A: "has spaces",
+      B: "x",
+    });
+  });
+});
+
+describe("formatValue", () => {
+  it("leaves simple values bare and quotes ones needing it", () => {
+    expect(formatValue("sk-123")).toBe("sk-123");
+    expect(formatValue("")).toBe("");
+    expect(formatValue("has space")).toBe('"has space"');
+    expect(formatValue("has#hash")).toBe('"has#hash"');
+  });
+});
+
+describe("renderEnv", () => {
+  it("overlays values while preserving comments, order, and blank lines", () => {
+    const out = renderEnv(TEMPLATE, {
+      LLM_PROVIDER: "openai",
+      OPENAI_API_KEY: "sk-test",
+      SEARCH_PROVIDER: "tavily",
+    });
+    expect(out).toContain("# Comment header");
+    expect(out).toContain("# ── LLM ──");
+    expect(out).toContain("LLM_PROVIDER=openai");
+    expect(out).toContain("OPENAI_API_KEY=sk-test");
+    expect(out).toContain("SEARCH_PROVIDER=tavily");
+    // Untouched template defaults remain.
+    expect(out).toContain("NODE_ENV=development");
+    expect(out).toContain("GEMINI_API_KEY=");
+    // A commented-out example line is never rewritten.
+    expect(out).toContain("# EXAMPLE_KEY=do-not-edit");
+  });
+
+  it("appends keys that are not present in the template", () => {
+    const out = renderEnv(TEMPLATE, { RAG_BACKEND: "lightrag" });
+    expect(out).toContain("Added by `deepinterview init`");
+    expect(out).toContain("RAG_BACKEND=lightrag");
+  });
+
+  it("round-trips: render then parse recovers the overlaid values", () => {
+    const out = renderEnv(TEMPLATE, {
+      GEMINI_API_KEY: "secret key with spaces",
+      LLM_PROVIDER: "gemini",
+    });
+    const parsed = parseEnv(out);
+    expect(parsed.GEMINI_API_KEY).toBe("secret key with spaces");
+    expect(parsed.LLM_PROVIDER).toBe("gemini");
+  });
+});

--- a/cli/src/lib/env-template.ts
+++ b/cli/src/lib/env-template.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure, side-effect-free helpers for reading and rendering the project's `.env`
+ * files. Kept dependency-free so the wizard's file logic is unit-testable
+ * without a TTY or filesystem.
+ */
+
+const KEY_LINE = /^(\s*)([A-Z][A-Z0-9_]*)=(.*)$/;
+
+function unquote(value: string): string {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Parse `KEY=VALUE` pairs from a `.env` body into a map. Comments, blank lines
+ * and malformed lines are skipped; surrounding quotes on a value are stripped.
+ */
+export function parseEnv(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Z][A-Z0-9_]*$/.test(key)) continue;
+    out[key] = unquote(line.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+/**
+ * Quote a value for a `.env` line only when it contains characters a dotenv
+ * parser would otherwise split on (whitespace, `#`) or quotes. Empty stays empty.
+ */
+export function formatValue(value: string): string {
+  if (value === "") return "";
+  if (/[\s#"']/.test(value)) return `"${value.replace(/(["\\])/g, "\\$1")}"`;
+  return value;
+}
+
+/**
+ * Render a `.env` file by overlaying `values` onto the annotated `template`
+ * (the `.env.example`), preserving its comments, ordering and blank lines. A key
+ * present in the template takes `values[key]` when provided, else keeps its
+ * template default. Keys in `values` absent from the template are appended under
+ * a trailing section so nothing the caller asked for is silently dropped.
+ */
+export function renderEnv(
+  template: string,
+  values: Record<string, string>,
+): string {
+  const seen = new Set<string>();
+  const lines = template.split(/\r?\n/).map((raw) => {
+    const match = raw.match(KEY_LINE);
+    if (!match) return raw;
+    const indent = match[1] ?? "";
+    const key = match[2];
+    if (key === undefined) return raw;
+    seen.add(key);
+    if (Object.prototype.hasOwnProperty.call(values, key)) {
+      return `${indent}${key}=${formatValue(values[key] ?? "")}`;
+    }
+    return raw;
+  });
+
+  const extras = Object.keys(values).filter((key) => !seen.has(key));
+  if (extras.length > 0) {
+    lines.push("");
+    lines.push("# Added by `deepinterview init` (keys not in .env.example):");
+    for (const key of extras)
+      lines.push(`${key}=${formatValue(values[key] ?? "")}`);
+  }
+  return lines.join("\n");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
 
   cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@deepinterview/shared':
         specifier: workspace:*
         version: link:../packages/shared
@@ -117,6 +120,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
 
   packages/ee:
     devDependencies:
@@ -267,6 +273,12 @@ packages:
 
   '@bufbuild/protobuf@1.10.1':
     resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -1858,6 +1870,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2362,6 +2377,17 @@ snapshots:
   '@aws/lambda-invoke-store@0.2.4': {}
 
   '@bufbuild/protobuf@1.10.1': {}
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -3655,6 +3681,8 @@ snapshots:
     optional: true
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Why

CLAUDE.md names `deepinterview init` "the key adoption lever", but it only copied `.env.example` → `.env` and printed *"Interactive wizard: coming soon."* — so a first-time contributor still hand-edited `.env`. This makes the clone-and-run story real.

## What

In a terminal, `init` now runs a guided wizard:

- **Pick a run mode** — *Live voice* / *Prep + scoring only* / *Offline demo* — and enter only the keys that mode needs. Offline writes mock providers (zero keys).
- **Secrets are masked**; an already-configured key is offered to *keep*, so re-running to update one value is safe and never re-types secrets.
- Writes the root `.env` by **overlaying answers onto the annotated `.env.example`** (comments + untouched defaults preserved), then syncs `apps/agent/.env` and `apps/web/.env.local`.

**Non-interactive** (CI / piped stdin / `--no-input` / `--yes`) keeps the original copy-from-template behaviour and the `--force` re-sync, so scripted setups are unchanged.

## Structure & tests

- Pure read/render logic extracted to `cli/src/lib/env-template.ts` (comment-preserving merge, quoting, round-trip) with **vitest** coverage — 6 tests.
- Adds `@clack/prompts` + a `test` script to the CLI package.

## Verification

- `typecheck` + `build` + prettier clean; `vitest` 6/6 green.
- Drove the interactive wizard over a PTY end-to-end:
  - **offline** → `LLM_PROVIDER=mock`, `SEARCH_PROVIDER=mock`, no keys.
  - **prep** → masked entry wrote `GEMINI_API_KEY` / `TAVILY_API_KEY`; untouched `STT_PROVIDER=deepgram` template default preserved.
- Non-interactive `--no-input` / `--force` sandbox run writes + re-syncs all three env files.