### PR TITLE
feat(kb): close the WP-8 ingest loop; key knowledge by session_id

### DIFF
--- a/apps/agent/src/deepinterview_agent/api/kb.py
+++ b/apps/agent/src/deepinterview_agent/api/kb.py
@@ -39,15 +39,6 @@ _INGEST_TIMEOUT = 60.0
 _QUERY_TIMEOUT = 20.0
 
 
-def _stub_track_id(req: KbIngestRequest) -> str:
-    """Deterministic offline track id: stable for a given user + file set.
-
-    No ``uuid4``/``hash()`` (both non-deterministic across runs) — a plain f-string
-    keeps the stub reproducible so callers can assert on it.
-    """
-    return f"trk-{req.user_id}-{len(req.files)}"
-
-
 async def _guarded(coro, *, label: str, timeout: float):
     """Await ``coro`` with a timeout; on ANY error return ``None`` (caller falls back)."""
     try:
@@ -57,31 +48,22 @@ async def _guarded(coro, *, label: str, timeout: float):
         return None
 
 
-async def _forward_ingest(base_url: str, req: KbIngestRequest) -> KbIngestResponse | None:
-    """POST the ingest to the LightRAG sidecar's ``/kb/ingest``; ``None`` on failure."""
-    import httpx  # noqa: PLC0415 - httpx is a core agent dep; lazy keeps import cheap
-
-    payload = {"user_id": req.user_id, "files": req.files}
-    async with httpx.AsyncClient(timeout=_INGEST_TIMEOUT) as client:
-        resp = await client.post(f"{base_url.rstrip('/')}/kb/ingest", json=payload)
-        resp.raise_for_status()
-        data = resp.json()
-    return KbIngestResponse(track_id=data.get("track_id", _stub_track_id(req)))
-
-
 @router.post("/api/kb/ingest", response_model=KbIngestResponse)
 async def kb_ingest(req: KbIngestRequest) -> KbIngestResponse:
+    # Ingest goes through the SAME knowledge adapter as /api/kb/query, so the
+    # store key (user_id) and backend selection stay consistent across both
+    # paths. With no LIGHTRAG_URL the adapter is MockKnowledge (deterministic
+    # offline stub); when configured it forwards to the sidecar's /kb/ingest and
+    # degrades to the stub on any failure rather than 5xx.
     deps = build_deps()
-    base_url = deps.settings.lightrag_url
-    if base_url:
-        forwarded = await _guarded(
-            _forward_ingest(base_url, req), label="ingest", timeout=_INGEST_TIMEOUT
-        )
-        if forwarded is not None:
-            return forwarded
-        # Sidecar configured but unreachable: degrade to the offline stub rather
-        # than 5xx, mirroring the coach's degrade-don't-raise policy.
-    return KbIngestResponse(track_id=_stub_track_id(req))
+    track_id = await _guarded(
+        deps.knowledge.ingest(req.user_id, req.files),
+        label="ingest",
+        timeout=_INGEST_TIMEOUT,
+    )
+    if track_id is None:
+        track_id = f"trk-{req.user_id}-{len(req.files)}"
+    return KbIngestResponse(track_id=track_id)
 
 
 @router.post("/api/kb/query", response_model=KbQueryResponse)

--- a/apps/agent/src/deepinterview_agent/core/adapters/knowledge.py
+++ b/apps/agent/src/deepinterview_agent/core/adapters/knowledge.py
@@ -24,16 +24,37 @@ log = get_logger(__name__)
 
 # Request timeout when querying the knowledge sidecar (seconds).
 _QUERY_TIMEOUT = 20.0
+# Ingest is heavier (parse + embed), so allow longer. Mirrors api/kb.py.
+_INGEST_TIMEOUT = 60.0
+
+
+def _stub_track_id(user_id: str, files: list[str]) -> str:
+    """Deterministic offline track id (stable for a given key + file set).
+
+    No ``uuid4``/``hash()`` (non-deterministic across runs) so callers/tests can
+    assert on it.
+    """
+    return f"trk-{user_id}-{len(files)}"
 
 
 @runtime_checkable
 class KnowledgeClient(Protocol):
-    """Grounded retrieval over a user's knowledge store."""
+    """Grounded retrieval over (and ingestion into) a user's knowledge store."""
 
     async def search(
         self, user_id: str, query: str, lang: str
     ) -> tuple[str, list[Citation]]:
         """Return ``(answer, citations)`` for ``query`` over ``user_id``'s store."""
+        ...
+
+    async def ingest(self, user_id: str, files: list[str]) -> str:
+        """Ingest ``files`` (raw text or fetchable URLs) into ``user_id``'s store.
+
+        Returns a ``track_id``. The ``user_id`` key MUST match the one later
+        passed to :meth:`search`, or the ingested docs are unreachable — in the
+        OSS auth-free flow that key is the ``session_id`` (see the prep pipeline
+        and the Study Coach, which both key knowledge by session).
+        """
         ...
 
 
@@ -57,6 +78,16 @@ class HttpKnowledge:
         answer = data.get("answer", "")
         citations = [Citation(**c) for c in data.get("citations", [])]
         return (answer, citations)
+
+    async def ingest(self, user_id: str, files: list[str]) -> str:
+        import httpx  # noqa: PLC0415 - httpx is a core agent dep; lazy keeps import cheap
+
+        payload = {"user_id": user_id, "files": files}
+        async with httpx.AsyncClient(timeout=_INGEST_TIMEOUT) as client:
+            resp = await client.post(f"{self._base_url}/kb/ingest", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+        return data.get("track_id", _stub_track_id(user_id, files))
 
 
 class MockKnowledge:
@@ -85,6 +116,10 @@ class MockKnowledge:
             ),
         ]
         return (answer, citations)
+
+    async def ingest(self, user_id: str, files: list[str]) -> str:
+        """Offline no-op: there is no store, so just return a deterministic id."""
+        return _stub_track_id(user_id, files)
 
 
 def _lightrag_url(settings: Settings) -> str | None:

--- a/apps/agent/src/deepinterview_agent/prep/__init__.py
+++ b/apps/agent/src/deepinterview_agent/prep/__init__.py
@@ -31,6 +31,54 @@ __all__ = ["run_prep", "run_prep_for_session", "build_prep_graph"]
 log = get_logger(__name__)
 
 
+async def _ingest_prep_materials(
+    session_id: str,
+    req: PrepRequest,
+    cv_text: str,
+    ctx: InterviewContext,
+    deps: Deps,
+) -> None:
+    """Ingest the prep documents (CV, JD, company intel) into the session's
+    knowledge store, keyed by ``session_id``.
+
+    Best-effort and self-contained: any knowledge failure is logged and
+    swallowed so it can never turn a successful prep into an ``error``. With no
+    knowledge sidecar configured the adapter is the offline mock (a no-op that
+    returns a deterministic track id), so this stays free in the default flow.
+    """
+    files: list[str] = []
+    if cv_text and cv_text.strip():
+        files.append(f"CANDIDATE CV\n\n{cv_text.strip()}")
+    if req.jd_text and req.jd_text.strip():
+        files.append(f"JOB DESCRIPTION — {req.company}\n\n{req.jd_text.strip()}")
+
+    company = ctx.company
+    intel_parts: list[str] = []
+    if company.summary:
+        intel_parts.append(company.summary)
+    if company.interview_process:
+        intel_parts.append(
+            "Interview process:\n- " + "\n- ".join(company.interview_process)
+        )
+    if company.recent_news:
+        intel_parts.append("Recent news:\n- " + "\n- ".join(company.recent_news))
+    if intel_parts:
+        files.append(f"COMPANY INTEL — {company.name}\n\n" + "\n\n".join(intel_parts))
+
+    if not files:
+        return
+    try:
+        track_id = await deps.knowledge.ingest(session_id, files)
+        log.info(
+            "prep: ingested %d doc(s) into the knowledge store for session %s (track %s)",
+            len(files),
+            session_id,
+            track_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - knowledge ingest is strictly best-effort
+        log.warning("prep: knowledge ingest failed for session %s (%s)", session_id, exc)
+
+
 async def run_prep(req: PrepRequest, deps: Deps) -> str:
     """Run the prep pipeline inline and return the new ``session_id``.
 
@@ -98,6 +146,12 @@ async def run_prep_for_session(
 
         await deps.repo.save_context(session_id, ctx)
         await deps.repo.update_status(session_id, "ready")
+
+        # Close the WP-8 loop: ingest the prep materials into THIS session's
+        # knowledge store so the Study Coach (which retrieves by session_id) can
+        # ground answers in the candidate's CV/JD/company intel. Keyed by
+        # session_id — the same key search() uses. Best-effort: never fail prep.
+        await _ingest_prep_materials(session_id, req, cv_text, ctx, deps)
     except Exception as exc:  # noqa: BLE001 - background task: record, don't propagate
         log.exception("run_prep_for_session(%s) failed: %s", session_id, exc)
         try:

--- a/apps/agent/tests/test_coach.py
+++ b/apps/agent/tests/test_coach.py
@@ -95,10 +95,15 @@ def test_coach_chat_grounds_when_backend_configured() -> None:
             return ("Grounded context.", [Citation(title="Prep notes", url="kb://x", snippet="s")])
 
     deps.settings.lightrag_url = "http://localhost:9621"
+    original_knowledge = deps.knowledge
     deps.knowledge = _FakeKnowledge()
     try:
         req = CoachChatRequest(session_id="sess_x", query="What is exactly-once?", lang="en")
         reply = asyncio.run(run_coach_chat(req, deps))
         assert len(reply.citations) >= 1
     finally:
+        # Restore BOTH mutated fields on the shared cached deps — leaving the
+        # _FakeKnowledge in place pollutes later tests (e.g. /api/kb/ingest now
+        # calls deps.knowledge.ingest, which this double doesn't implement).
         deps.settings.lightrag_url = original
+        deps.knowledge = original_knowledge

--- a/apps/agent/tests/test_knowledge.py
+++ b/apps/agent/tests/test_knowledge.py
@@ -56,3 +56,10 @@ def test_get_knowledge_returns_http_with_lightrag_url(monkeypatch) -> None:
     monkeypatch.setenv("LIGHTRAG_URL", "http://lightrag:9621")
     client = get_knowledge(Settings())
     assert isinstance(client, HttpKnowledge)
+
+
+def test_mock_knowledge_ingest_returns_deterministic_stub() -> None:
+    track = _run(MockKnowledge().ingest("sess_abc", ["doc one", "doc two"]))
+    assert track == "trk-sess_abc-2"
+    # Stable across calls (no uuid4/hash) so callers/tests can assert on it.
+    assert track == _run(MockKnowledge().ingest("sess_abc", ["doc one", "doc two"]))

--- a/apps/agent/tests/test_prep.py
+++ b/apps/agent/tests/test_prep.py
@@ -78,3 +78,53 @@ def test_run_prep_maps_search_results_into_company_citations() -> None:
     for c in ctx.company.citations:
         assert c.title
         assert c.url
+
+
+class _RecordingKnowledge:
+    """Knowledge adapter spy: records ingest calls so a test can assert that prep
+    closed the WP-8 loop with the right key + documents."""
+
+    def __init__(self) -> None:
+        self.ingests: list[tuple[str, list[str]]] = []
+
+    async def search(self, user_id: str, query: str, lang: str):  # noqa: ANN201
+        return ("", [])
+
+    async def ingest(self, user_id: str, files: list[str]) -> str:
+        self.ingests.append((user_id, list(files)))
+        return f"trk-{user_id}-{len(files)}"
+
+
+def test_run_prep_ingests_materials_keyed_by_session_id(monkeypatch) -> None:
+    """Prep must ingest the CV/JD/company intel into the knowledge store keyed by
+    session_id — the SAME key the Study Coach retrieves with — so the grounded
+    coach loop is reachable (the WP-8 acceptance was structurally unmet before)."""
+    deps = build_deps()
+    recorder = _RecordingKnowledge()
+    monkeypatch.setattr(deps, "knowledge", recorder)
+
+    session_id = asyncio.run(run_prep(_request(), deps))
+
+    assert recorder.ingests, "prep must ingest the prep materials"
+    key, files = recorder.ingests[0]
+    # Keyed by session_id (not user.id) — aligns ingest with the coach's query key.
+    assert key == session_id
+    blob = "\n\n".join(files)
+    assert "CANDIDATE CV" in blob
+    assert "JOB DESCRIPTION" in blob
+    # The actual JD content is carried through, not just a header.
+    assert "distributed payment systems" in blob
+
+
+def test_run_prep_ingest_failure_does_not_break_prep(monkeypatch) -> None:
+    """A knowledge-ingest failure must NEVER turn a successful prep into 'error':
+    ingestion is strictly best-effort and self-contained."""
+    deps = build_deps()
+
+    class _BoomKnowledge(_RecordingKnowledge):
+        async def ingest(self, user_id: str, files: list[str]) -> str:
+            raise RuntimeError("kb sidecar down")
+
+    monkeypatch.setattr(deps, "knowledge", _BoomKnowledge())
+    session_id = asyncio.run(run_prep(_request(), deps))
+    assert deps.repo.get_status(session_id) == "ready"

--- a/apps/web/app/api/kb/query/route.ts
+++ b/apps/web/app/api/kb/query/route.ts
@@ -13,11 +13,14 @@ export const dynamic = "force-dynamic";
 
 /**
  * Incoming client body. We do NOT validate with the shared `KbQueryRequestSchema`
- * here: that requires `user_id` (resolved server-side, not sent by the browser)
- * and a strict `LanguageSchema`. The client only sends `{query, lang}`; `lang`
- * falls back to "en" if absent/unsupported.
+ * here: that names the store key `user_id`, but the OSS flow is auth-free and
+ * keys the knowledge store by `session_id` (the same key the prep pipeline
+ * ingests under and the Study Coach retrieves with). The client sends
+ * `{session_id?, query, lang}`; `session_id` defaults to "anonymous" and `lang`
+ * falls back to "en".
  */
 const BodySchema = z.object({
+  session_id: z.string().default("anonymous"),
   query: z.string().min(1),
   lang: LanguageSchema.catch("en").default("en"),
 });
@@ -79,14 +82,14 @@ export async function POST(request: Request) {
     return NextResponse.json(mockAnswer(body.query));
   }
 
-  const userId = user?.id ?? "anonymous";
-
   try {
     const upstream = await fetch(`${lightragUrl.replace(/\/$/, "")}/kb/query`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      // Scope retrieval by session_id — the key the prep pipeline ingested
+      // under and the agent coach queries with — so the docs are reachable.
       body: JSON.stringify({
-        user_id: userId,
+        user_id: body.session_id,
         query: body.query,
         lang: body.lang,
       }),

--- a/apps/web/app/prep/page.tsx
+++ b/apps/web/app/prep/page.tsx
@@ -143,7 +143,7 @@ export default async function PrepPage({
       {/* Study plan + grounded chat side by side on wide screens */}
       <section className="mt-10 grid gap-8 lg:grid-cols-[1.15fr_1fr]">
         <StudyPlan modules={studyModules} weakAreas={weakAreas} />
-        <GroundedChat />
+        <GroundedChat sessionId={sessionId} />
       </section>
 
       {/* Flashcards + mastery graph */}

--- a/apps/web/components/prep/grounded-chat.tsx
+++ b/apps/web/components/prep/grounded-chat.tsx
@@ -23,13 +23,17 @@ const SUGGESTIONS = [
 ];
 
 /**
- * Grounded coach chat. The user asks; we call `queryKnowledge` (which proxies to
- * LightRAG or a mock), then render the answer with citation chips that link out.
+ * Grounded coach chat. The user asks; we call `askCoach` (which proxies to the
+ * agent's Study Coach or a mock), then render the answer with citation chips
+ * that link out. When a `sessionId` is provided (the prep page passes the linked
+ * interview's id via `?session=`), retrieval is scoped to THAT session's
+ * knowledge store — the same key the prep pipeline ingested the CV/JD/company
+ * intel under — so answers are grounded in the candidate's own materials.
  * The thinking state is deliberately "RAG-delay friendly" — it names the phase
  * (retrieving → grounding) so a multi-second retrieval feels intentional, not
  * stalled.
  */
-export function GroundedChat() {
+export function GroundedChat({ sessionId }: { sessionId?: string | null }) {
   const [turns, setTurns] = useState<ChatTurn[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -66,7 +70,7 @@ export function GroundedChat() {
     setLoading(true);
 
     try {
-      const res = await askCoach(q, "en");
+      const res = await askCoach(q, "en", sessionId ?? "anonymous");
       setTurns((prev) => [
         ...prev,
         {

--- a/apps/web/lib/kb.ts
+++ b/apps/web/lib/kb.ts
@@ -15,11 +15,12 @@ export type { KbQueryResponse, Citation };
 export async function queryKnowledge(
   query: string,
   lang: Language = "en",
+  sessionId = "anonymous",
 ): Promise<KbQueryResponse> {
   const res = await fetch("/api/kb/query", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ query, lang }),
+    body: JSON.stringify({ session_id: sessionId, query, lang }),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Why

The Prep Coach's "grounded with citations" was **structurally unreachable**: nothing ever ingested into the per-user knowledge store, and the query paths keyed on **mismatched identities** — web `kb/query` used `user.id` (always `"anonymous"` in the auth-free OSS), while the agent coach retrieves by `session_id`. So every retrieval returned empty even with a real backend, and WP-8's acceptance couldn't be met.

## What

Close the loop, keyed consistently by **`session_id`** (the key the coach already uses):

- **Knowledge adapter** — add `ingest(user_id, files)` to the protocol + `HttpKnowledge` (POST `/kb/ingest`) + `MockKnowledge` (deterministic offline stub).
- **`api/kb.py`** — route `/api/kb/ingest` through `deps.knowledge.ingest`, so ingest and query share one adapter, backend selection, and degrade-don't-5xx policy.
- **Prep pipeline** — after a session is `ready`, best-effort ingest the **CV + JD + company intel** into that session's store (never fails prep).
- **Web** — `/api/kb/query` and `lib/kb` now scope by `session_id`; `GroundedChat` takes the prep page's `?session=` id and passes it to the coach, so answers ground in the linked interview's materials.

Also fixes a **pre-existing test-isolation leak**: `test_coach` left a `_FakeKnowledge` (no `ingest`) on the cached deps — harmless until ingest started routing through the adapter.

## Verification

- Agent **187 tests** pass (new: prep ingests keyed by session_id; ingest failure doesn't break prep; mock ingest deterministic), ruff clean.
- Web build + typecheck + prettier green.
- **Real round-trip** against the naive RAG sidecar: ingest+query by `session_id` returns the grounded doc; a different key returns empty (per-session isolation).