### PR TITLE
design: logo refresh — outlined-geometry marks (Di + loop), no font dependency

### DIFF
--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,32 +1,12 @@
 <svg width="140" height="140" viewBox="0 0 140 140" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="DeepInterview">
-  <title>DeepInterview</title>
-  <!-- Editorial mark: a rounded square plate with a serif "Di" and a hairline
-       voice-loop arc. Brand: paper plate, deep-indigo accent (#4338CA),
-       Fraunces-style serif glyph. Matches landing-page.html's mark. -->
-  <defs>
-    <clipPath id="plate">
-      <rect x="6" y="6" width="128" height="128" rx="30" />
-    </clipPath>
-  </defs>
-
-  <!-- plate -->
+  <title>DeepInterview — candidate B "Di"</title>
+  <!-- B: the wordmark's initials as pure geometry. The i's tittle is the one
+       indigo accent — the speaking dot. Reads as "Di" at 140px and as a
+       confident glyph pair at 16px. -->
   <rect x="6" y="6" width="128" height="128" rx="30" fill="#FBF9F4" />
   <rect x="6.75" y="6.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#1A1A1A" stroke-width="1.5" />
-
-  <g clip-path="url(#plate)">
-    <!-- voice loop: a thin indigo arc sweeping under the glyph, the prep -> live -> feedback loop -->
-    <path d="M28 96 a42 42 0 0 0 84 0" fill="none" stroke="#4338CA" stroke-width="2.5" stroke-linecap="round" opacity="0.9" />
-    <!-- loop endpoint dots -->
-    <circle cx="28" cy="96" r="3.5" fill="#4338CA" />
-    <circle cx="112" cy="96" r="3.5" fill="#4338CA" />
-
-    <!-- serif "Di" wordmark glyph -->
-    <text x="70" y="78" text-anchor="middle"
-          font-family="Fraunces, Georgia, 'Times New Roman', serif"
-          font-size="62" font-weight="600" font-style="italic"
-          letter-spacing="-1" fill="#1A1A1A">Di</text>
-
-    <!-- a small indigo "speaking" tick above the i, hints at the live mic -->
-    <circle cx="89" cy="36" r="3.2" fill="#4338CA" />
-  </g>
+  <path d="M38 40 H56 A30 30 0 0 1 56 100 H38 Z"
+        fill="none" stroke="#1A1A1A" stroke-width="10" stroke-linejoin="round" />
+  <path d="M101 62 V100" stroke="#1A1A1A" stroke-width="10" stroke-linecap="round" />
+  <circle cx="101" cy="45" r="6.5" fill="#4338CA" />
 </svg>

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -1,4 +1,5 @@
 import { Container } from "@/components/ui/container";
+import { BrandMark } from "@/components/ui/brand-mark";
 import { GITHUB_URL, DOCS_URL } from "@/lib/site";
 
 type FooterLink = { href: string; label: string; external?: boolean };
@@ -60,9 +61,7 @@ export function Footer() {
         <div className="mb-9 grid grid-cols-2 gap-[30px] md:grid-cols-[2fr_1fr_1fr_1fr]">
           <div>
             <div className="mb-3 flex items-center gap-[9px]">
-              <span className="grid h-[22px] w-[22px] place-items-center rounded-md border-[1.5px] border-ink font-serif text-sm leading-none">
-                D
-              </span>
+              <BrandMark size={22} />
               <span className="text-[17px] font-semibold tracking-[-0.01em]">
                 DeepInterview
               </span>

--- a/apps/web/components/landing/nav.tsx
+++ b/apps/web/components/landing/nav.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { features } from "@deepinterview/ee";
 import { Container } from "@/components/ui/container";
 import { buttonClasses } from "@/components/ui/button";
+import { BrandMark } from "@/components/ui/brand-mark";
 import { MobileMenu } from "@/components/landing/mobile-menu";
 import { GITHUB_URL } from "@/lib/site";
 
@@ -17,9 +18,7 @@ export function Nav() {
     <nav className="sticky top-0 z-50 border-b border-line bg-paper/80 backdrop-blur-md">
       <Container className="flex h-[66px] items-center justify-between">
         <a href="#top" className="flex items-center gap-[9px]">
-          <span className="grid h-[22px] w-[22px] place-items-center rounded-md border-[1.5px] border-ink font-serif text-sm leading-none">
-            D
-          </span>
+          <BrandMark size={22} />
           <span className="text-[17px] font-semibold tracking-[-0.01em]">
             DeepInterview
           </span>

--- a/apps/web/components/ui/brand-mark.tsx
+++ b/apps/web/components/ui/brand-mark.tsx
@@ -1,0 +1,51 @@
+/**
+ * <BrandMark> — the small-context DeepInterview mark ("Di" as pure geometry,
+ * the i's tittle as the indigo speaking dot). Inline SVG so it renders
+ * identically everywhere — no font dependency, no asset request. The
+ * large-context variant (with the prep → interview → feedback loop arc)
+ * lives in assets/logo.svg for the README hero and big lockups.
+ */
+export function BrandMark({
+  size = 22,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 140 140"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <rect x="6" y="6" width="128" height="128" rx="30" fill="#FBF9F4" />
+      <rect
+        x="6.75"
+        y="6.75"
+        width="126.5"
+        height="126.5"
+        rx="29.25"
+        fill="none"
+        stroke="#1A1A1A"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M38 40 H56 A30 30 0 0 1 56 100 H38 Z"
+        fill="none"
+        stroke="#1A1A1A"
+        strokeWidth="10"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M101 62 V100"
+        stroke="#1A1A1A"
+        strokeWidth="10"
+        strokeLinecap="round"
+      />
+      <circle cx="101" cy="45" r="6.5" fill="#4338CA" />
+    </svg>
+  );
+}

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,32 +1,14 @@
 <svg width="140" height="140" viewBox="0 0 140 140" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="DeepInterview">
-  <title>DeepInterview</title>
-  <!-- Editorial mark: a rounded square plate with a serif "Di" and a hairline
-       voice-loop arc. Brand: paper plate, deep-indigo accent (#4338CA),
-       Fraunces-style serif glyph. Matches landing-page.html's mark. -->
-  <defs>
-    <clipPath id="plate">
-      <rect x="6" y="6" width="128" height="128" rx="30" />
-    </clipPath>
-  </defs>
-
-  <!-- plate -->
+  <title>DeepInterview — candidate C "The loop"</title>
+  <!-- C: the current mark, refined. Keeps the signature prep -> interview ->
+       feedback loop as a single indigo underline arc (no endpoint dots, no
+       floating tick), with the "Di" rebuilt as outlined geometry so it renders
+       identically everywhere. -->
   <rect x="6" y="6" width="128" height="128" rx="30" fill="#FBF9F4" />
   <rect x="6.75" y="6.75" width="126.5" height="126.5" rx="29.25" fill="none" stroke="#1A1A1A" stroke-width="1.5" />
-
-  <g clip-path="url(#plate)">
-    <!-- voice loop: a thin indigo arc sweeping under the glyph, the prep -> live -> feedback loop -->
-    <path d="M28 96 a42 42 0 0 0 84 0" fill="none" stroke="#4338CA" stroke-width="2.5" stroke-linecap="round" opacity="0.9" />
-    <!-- loop endpoint dots -->
-    <circle cx="28" cy="96" r="3.5" fill="#4338CA" />
-    <circle cx="112" cy="96" r="3.5" fill="#4338CA" />
-
-    <!-- serif "Di" wordmark glyph -->
-    <text x="70" y="78" text-anchor="middle"
-          font-family="Fraunces, Georgia, 'Times New Roman', serif"
-          font-size="62" font-weight="600" font-style="italic"
-          letter-spacing="-1" fill="#1A1A1A">Di</text>
-
-    <!-- a small indigo "speaking" tick above the i, hints at the live mic -->
-    <circle cx="89" cy="36" r="3.2" fill="#4338CA" />
-  </g>
+  <path d="M38 34 H56 A29 29 0 0 1 56 92 H38 Z"
+        fill="none" stroke="#1A1A1A" stroke-width="10" stroke-linejoin="round" />
+  <path d="M100 56 V92" stroke="#1A1A1A" stroke-width="10" stroke-linecap="round" />
+  <circle cx="100" cy="40" r="5.5" fill="#1A1A1A" />
+  <path d="M40 104 a30 16 0 0 0 60 0" fill="none" stroke="#4338CA" stroke-width="3" stroke-linecap="round" />
 </svg>


### PR DESCRIPTION
Replaces the live-text Fraunces mark (which rendered in fallback serifs on GitHub and in favicons) with two outlined-geometry marks that render identically everywhere:

- **assets/logo.svg** — large-context mark for the README hero: geometric "Di" with the signature prep → interview → feedback loop as one clean indigo underline arc (endpoint dots + floating tick removed).
- **apps/web/app/icon.svg** — small-context mark for the favicon: "Di" with the i's tittle as the single indigo speaking dot.
- **New `<BrandMark>`** component replaces the CSS-drawn "D" chips in the landing nav and footer, so the site header carries the real mark.

Candidates were reviewed at 140/32/16 px on light and dark grounds; picked B (small) + C (large) as a family. Typecheck + prettier clean; header verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)