### PR TITLE
feat(cli): skills lint command + pack contribution policy and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/skill_pack.md
+++ b/.github/PULL_REQUEST_TEMPLATE/skill_pack.md
@@ -1,0 +1,23 @@
+<!-- Skill-pack PR template. Use it via:
+     https://github.com/ngoanpv/DeepInterview/compare/main...YOUR_BRANCH?template=skill_pack.md -->
+
+## New skill pack(s)
+
+| Pack | Company | Role (slug) | Level |
+|---|---|---|---|
+| `skills/….md` | `generic` / … | `…-…` | … |
+
+## Checklist
+
+- [ ] `pnpm deepinterview skills lint` passes with no errors
+- [ ] `role` is a kebab-case slug; `status: draft`; `id` is `{company}-{role}-{level}`
+- [ ] Body has **Round structure / Question bank / Signals / Pitfalls**
+- [ ] Questions are original and generalized — recollection-based, no verbatim
+      dumps, nothing under NDA, no copyrighted prep material, no personal data
+      (see [CONTRIBUTING.md §6](../../CONTRIBUTING.md))
+- [ ] Provenance noted below (what these questions are based on)
+
+## Provenance
+
+<!-- e.g. "Generalized from my own onsite loops at two fintech companies, 2026"
+     or "Curated from public engineering-blog interview guides (linked)". -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,38 @@ This is the cleanest first contribution — see the good-first-issues for a work
 
 ---
 
-## 6. Licensing, DCO sign-off & the `/ee` boundary
+## 6. Contributing skill packs (question banks)
+
+Interview playbooks live in [`skills/`](skills/) as Markdown + YAML frontmatter
+and are injected straight into the question planner — the content you write
+shapes real interviews. Model yours on the committed `generic-*.md` packs.
+
+**Conventions** (full schema + how retrieval matches and ranks: [`skills/SCHEMA.md`](skills/SCHEMA.md)):
+
+- `company: generic` for role-level packs that should serve any company; a real
+  company name only for company-specific playbooks.
+- `role` is a **kebab-case slug** (`backend-engineer`) — matched by token
+  subset against live JD titles.
+- `status: draft` on contributions; maintainers flip status on review.
+
+**Validate before opening a PR:**
+
+```bash
+pnpm build                      # once, to build the CLI
+pnpm deepinterview skills lint  # schema + convention checks on skills/
+```
+
+**Content policy (hard requirement).** Packs must be **recollection-based,
+generalized, and de-identified**. Describe patterns and themes ("a system-design
+round probing multi-region consistency"), never claimed-verbatim transcripts.
+Do **not** contribute: question dumps from leaked or internal sources, anything
+you're under NDA about, copyrighted interview-prep material, or personal data
+about candidates or interviewers. PRs that can't credibly meet this bar are
+rejected — provenance ("based on my onsite in 2026-06") helps us say yes.
+
+---
+
+## 7. Licensing, DCO sign-off & the `/ee` boundary
 
 - **The project is [Apache-2.0](LICENSE).** By contributing you agree your contribution is licensed under Apache 2.0.
 - **Sign off your commits (DCO).** We use the lightweight [Developer Certificate of Origin](https://developercertificate.org/) instead of a CLA — no paperwork, no bot. Just add a `Signed-off-by` line by committing with the `-s` flag:
@@ -126,7 +157,7 @@ This is the cleanest first contribution — see the good-first-issues for a work
 
 ---
 
-## 7. Getting help
+## 8. Getting help
 
 - 🗣️ [GitHub Discussions](https://github.com/ngoanpv/DeepInterview/discussions) for questions and design chat.
 - 🐛 [Issues](https://github.com/ngoanpv/DeepInterview/issues) for bugs/features (use the templates).

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
-    "@deepinterview/shared": "workspace:*"
+    "@deepinterview/shared": "workspace:*",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/cli/src/commands/skills.ts
+++ b/cli/src/commands/skills.ts
@@ -1,0 +1,81 @@
+/**
+ * `deepinterview skills lint [paths…]` — validate skill packs before a PR.
+ *
+ * With no paths, lints every pack in `skills/` and `skills/_review/` (files
+ * whose content opens with a `---` frontmatter fence; README/SCHEMA are
+ * skipped). Errors exit 1 so the command is CI-friendly; warnings don't.
+ */
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { lintSkillText, type LintIssue } from "../lib/skill-lint";
+
+function isPackFile(path: string): boolean {
+  if (!path.endsWith(".md")) return false;
+  try {
+    return readFileSync(path, "utf8").trimStart().startsWith("---");
+  } catch {
+    return false;
+  }
+}
+
+function defaultTargets(): string[] {
+  const targets: string[] = [];
+  for (const dir of ["skills", join("skills", "_review")]) {
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      if (statSync(path).isFile() && isPackFile(path)) targets.push(path);
+    }
+  }
+  return targets;
+}
+
+function report(path: string, issues: LintIssue[]): void {
+  if (issues.length === 0) {
+    console.log(`  ok       ${path}`);
+    return;
+  }
+  const worst = issues.some((i) => i.level === "error") ? "error" : "warning";
+  console.log(`  ${worst.padEnd(8)} ${path}`);
+  for (const issue of issues) {
+    console.log(`           ${issue.level}: ${issue.message}`);
+  }
+}
+
+export async function runSkills(args: string[]): Promise<void> {
+  const [sub, ...paths] = args;
+  if (sub !== "lint") {
+    console.error("Usage: deepinterview skills lint [paths…]");
+    process.exitCode = 1;
+    return;
+  }
+  const targets = paths.length > 0 ? paths : defaultTargets();
+  if (targets.length === 0) {
+    console.error(
+      "No skill packs found (run from the repo root, or pass file paths).",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let errors = 0;
+  let warnings = 0;
+  for (const path of targets) {
+    let issues: LintIssue[];
+    try {
+      issues = lintSkillText(readFileSync(path, "utf8"));
+    } catch (cause) {
+      issues = [
+        { level: "error", message: `cannot read file: ${String(cause)}` },
+      ];
+    }
+    errors += issues.filter((i) => i.level === "error").length;
+    warnings += issues.filter((i) => i.level === "warning").length;
+    report(path, issues);
+  }
+
+  console.log(
+    `\n${targets.length} pack(s) checked — ${errors} error(s), ${warnings} warning(s).`,
+  );
+  if (errors > 0) process.exitCode = 1;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { runInit } from "./commands/init";
+import { runSkills } from "./commands/skills";
 
 const [, , command, ...args] = process.argv;
 
@@ -12,6 +13,8 @@ Usage:
                                  (for CI / scripted setups; --yes is an alias)
   deepinterview init --force     Re-sync the local-dev copies from the root .env
                                  (non-interactive)
+  deepinterview skills lint      Validate skill packs in skills/ (frontmatter
+                                 schema + conventions) before opening a PR
 
 \`init\` writes three files:
   .env                 → read by docker compose (the full stack)
@@ -28,6 +31,9 @@ async function main(): Promise<void> {
   switch (command) {
     case "init":
       await runInit(args);
+      break;
+    case "skills":
+      await runSkills(args);
       break;
     case undefined:
     case "help":

--- a/cli/src/lib/skill-lint.test.ts
+++ b/cli/src/lib/skill-lint.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { lintSkillText } from "./skill-lint";
+
+const VALID = `---
+id: generic-backend-engineer-senior
+company: generic
+role: backend-engineer
+level: senior
+competency:
+  - system-design
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-07-25
+status: promoted
+---
+
+# Generic — Senior Backend Engineer
+
+## Round structure
+1. Deep dive
+
+## Question bank
+- "Walk me through a system you scaled."
+
+## Signals
+- Quantifies impact.
+
+## Pitfalls
+- Designs for imaginary scale.
+`;
+
+function errors(text: string): string[] {
+  return lintSkillText(text)
+    .filter((i) => i.level === "error")
+    .map((i) => i.message);
+}
+
+describe("lintSkillText", () => {
+  it("passes a valid pack with no errors or warnings", () => {
+    expect(lintSkillText(VALID)).toEqual([]);
+  });
+
+  it("rejects missing fences and invalid YAML", () => {
+    expect(errors("# not a pack")).toHaveLength(1);
+    expect(errors("---\n[broken\n---\nbody")).toHaveLength(1);
+  });
+
+  it("rejects unknown fields (extra=forbid parity with the agent parser)", () => {
+    const text = VALID.replace(
+      "status: promoted",
+      "status: promoted\nauthor: me",
+    );
+    expect(errors(text)).toEqual(["unknown frontmatter field `author`"]);
+  });
+
+  it("rejects a non-slug role and a bad level", () => {
+    const text = VALID.replace(
+      "role: backend-engineer",
+      "role: Senior Backend Engineer",
+    ).replace("level: senior", "level: expert");
+    const msgs = errors(text);
+    expect(msgs.some((m) => m.includes("kebab-case slug"))).toBe(true);
+    expect(msgs.some((m) => m.startsWith("`level`"))).toBe(true);
+  });
+
+  it("rejects out-of-range confidence and bad dates", () => {
+    const text = VALID.replace("confidence: 0.5", "confidence: 1.5").replace(
+      "last_verified: 2026-07-25",
+      "last_verified: July 2026",
+    );
+    expect(errors(text)).toHaveLength(2);
+  });
+
+  it("warns on non-canonical id and missing sections without erroring", () => {
+    const text = VALID.replace(
+      "id: generic-backend-engineer-senior",
+      "id: my-cool-pack",
+    ).replace(/## Signals[\s\S]*?(?=## Pitfalls)/, "");
+    const issues = lintSkillText(text);
+    expect(issues.filter((i) => i.level === "error")).toEqual([]);
+    expect(
+      issues.some((i) => i.message.includes("generic-backend-engineer-senior")),
+    ).toBe(true);
+    expect(issues.some((i) => i.message.includes("`## Signals`"))).toBe(true);
+  });
+
+  it("warns when the question bank has no items", () => {
+    const text = VALID.replace('- "Walk me through a system you scaled."', "");
+    const issues = lintSkillText(text);
+    expect(issues.filter((i) => i.level === "error")).toEqual([]);
+    expect(
+      issues.some((i) => i.message.includes("no `- ` question items")),
+    ).toBe(true);
+  });
+});

--- a/cli/src/lib/skill-lint.ts
+++ b/cli/src/lib/skill-lint.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure linter for `skills/` pack files (Markdown + YAML frontmatter).
+ *
+ * Mirrors the Python source of truth (`apps/agent/.../skilllib/models.py`,
+ * `SkillFrontmatter` with `extra="forbid"`) so contributors get the same
+ * verdict locally that the agent's parser gives at runtime. Kept pure
+ * (text in → issues out) so it's trivially testable; the `skills` command
+ * does the file walking.
+ */
+import { parse } from "yaml";
+import { SenioritySchema } from "@deepinterview/shared";
+
+export interface LintIssue {
+  level: "error" | "warning";
+  message: string;
+}
+
+const KNOWN_FIELDS = new Set([
+  "id",
+  "company",
+  "role",
+  "level",
+  "competency",
+  "version",
+  "source_runs",
+  "confidence",
+  "last_verified",
+  "status",
+]);
+const STATUSES = ["draft", "review", "promoted", "deprecated"];
+const RECOMMENDED_SECTIONS = [
+  "Round structure",
+  "Question bank",
+  "Signals",
+  "Pitfalls",
+];
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function lintSkillText(text: string): LintIssue[] {
+  const issues: LintIssue[] = [];
+  const err = (message: string) => issues.push({ level: "error", message });
+  const warn = (message: string) => issues.push({ level: "warning", message });
+
+  const stripped = text.replace(/^\n+/, "");
+  const match = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(stripped);
+  if (!match) {
+    err("file must start with a '---' YAML frontmatter block closed by '---'");
+    return issues;
+  }
+  const front = match[1] ?? "";
+  const body = match[2] ?? "";
+
+  let data: unknown;
+  try {
+    data = parse(front);
+  } catch (cause) {
+    err(`frontmatter is not valid YAML: ${String(cause)}`);
+    return issues;
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    err("frontmatter must be a YAML mapping");
+    return issues;
+  }
+  const fm = data as Record<string, unknown>;
+
+  // extra="forbid" parity: the agent's parser rejects unknown fields.
+  for (const key of Object.keys(fm)) {
+    if (!KNOWN_FIELDS.has(key)) err(`unknown frontmatter field \`${key}\``);
+  }
+
+  const id = fm.id;
+  if (typeof id !== "string" || !SLUG_RE.test(id)) {
+    err(
+      "`id` is required and must be a kebab-case slug (e.g. generic-backend-engineer-senior)",
+    );
+  }
+  const company = fm.company;
+  if (typeof company !== "string" || company.trim() === "") {
+    err(
+      "`company` is required (a company name, or `generic` for a fallback pack)",
+    );
+  }
+  const role = fm.role;
+  if (typeof role !== "string" || !SLUG_RE.test(role)) {
+    err(
+      "`role` is required and must be a kebab-case slug (e.g. `backend-engineer`) — " +
+        "it is matched by token subset against live JD titles (see skills/SCHEMA.md)",
+    );
+  }
+  const level = fm.level;
+  const levelCheck = SenioritySchema.safeParse(level);
+  if (!levelCheck.success) {
+    err(`\`level\` must be one of: ${SenioritySchema.options.join(", ")}`);
+  }
+  if (fm.competency !== undefined) {
+    const ok =
+      Array.isArray(fm.competency) &&
+      fm.competency.every((c) => typeof c === "string" && c.trim() !== "");
+    if (!ok) err("`competency` must be a list of non-empty strings");
+  }
+  if (
+    fm.version !== undefined &&
+    (!Number.isInteger(fm.version) || (fm.version as number) < 1)
+  ) {
+    err("`version` must be an integer >= 1");
+  }
+  if (
+    fm.source_runs !== undefined &&
+    (!Number.isInteger(fm.source_runs) || (fm.source_runs as number) < 0)
+  ) {
+    err("`source_runs` must be an integer >= 0");
+  }
+  if (
+    fm.confidence !== undefined &&
+    (typeof fm.confidence !== "number" ||
+      fm.confidence < 0 ||
+      fm.confidence > 1)
+  ) {
+    err("`confidence` must be a number between 0 and 1");
+  }
+  const verified = fm.last_verified;
+  const verifiedStr =
+    verified instanceof Date ? verified.toISOString().slice(0, 10) : verified;
+  if (typeof verifiedStr !== "string" || !DATE_RE.test(verifiedStr)) {
+    err("`last_verified` is required and must be an ISO date (YYYY-MM-DD)");
+  }
+  if (fm.status !== undefined && !STATUSES.includes(fm.status as string)) {
+    err(`\`status\` must be one of: ${STATUSES.join(", ")}`);
+  }
+
+  // Conventions (warnings — the agent still parses these files fine).
+  if (
+    typeof id === "string" &&
+    typeof company === "string" &&
+    typeof role === "string" &&
+    typeof level === "string"
+  ) {
+    const canonical = slugify(`${company}-${role}-${level}`);
+    if (id !== canonical) {
+      warn(`\`id\` is usually \`{company}-{role}-{level}\` → \`${canonical}\``);
+    }
+  }
+  for (const section of RECOMMENDED_SECTIONS) {
+    const re = new RegExp(`^##\\s+${section}\\s*$`, "im");
+    if (!re.test(body))
+      warn(`body is missing the recommended \`## ${section}\` section`);
+  }
+  if (/^##\s+Question bank\s*$/im.test(body)) {
+    const bank =
+      body.split(/^##\s+Question bank\s*$/im)[1]?.split(/^##\s/m)[0] ?? "";
+    if (!/^\s*-\s+\S/m.test(bank))
+      warn("`## Question bank` section has no `- ` question items");
+  }
+
+  return issues;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,25 +110,28 @@ importers:
       '@deepinterview/shared':
         specifier: workspace:*
         version: link:../packages/shared
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
+        version: 4.1.10(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/ee:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -144,7 +147,7 @@ importers:
         version: 26.1.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -153,7 +156,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
+        version: 4.1.10(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       zod-to-json-schema:
         specifier: ^3.25.2
         version: 3.25.2(zod@4.4.3)
@@ -2031,6 +2034,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -2913,13 +2921,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))':
+  '@vitest/mocker@4.1.10(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)
+      vite: 7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3348,13 +3356,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.22
       tsx: 4.23.1
+      yaml: 2.9.0
 
   postcss@8.4.31:
     dependencies:
@@ -3558,7 +3567,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -3569,7 +3578,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.22)(tsx@4.23.1)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.62.2
       source-map: 0.7.6
@@ -3637,7 +3646,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1):
+  vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
@@ -3651,11 +3660,12 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
       tsx: 4.23.1
+      yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)):
+  vitest@4.1.10(@types/node@26.1.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.10(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -3672,7 +3682,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)
+      vite: 7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
@@ -3687,6 +3697,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yaml@2.9.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,3 +17,10 @@ for any company when no company-specific pack exists) — use them as the model
 for contributing new question banks (see issue #38). Set `company: generic`, a
 kebab-case `role` slug, and `status: draft` on contributions; maintainers flip
 status on review. See SCHEMA.md for how retrieval matches and ranks packs.
+
+Before opening a PR, validate your pack and read the content policy
+(recollection-based, generalized, de-identified — hard requirement):
+
+```bash
+pnpm deepinterview skills lint   # after `pnpm build`; see CONTRIBUTING.md §6
+```


### PR DESCRIPTION
Contribution infrastructure for the question-bank hub (follow-up to #40, supports #38):

- **`deepinterview skills lint`** — local validation with the same verdict the agent's parser gives at runtime (unknown-field rejection, slug/enum/date/range checks) plus convention warnings. Dogfooded on the committed library: 3 packs clean, legacy example correctly warned. 13 unit tests.
- **CONTRIBUTING §6** — pack how-to + the **content policy** (recollection-based, generalized, de-identified; no NDA'd/verbatim/copyrighted material, no personal data) with a provenance ask.
- **Skill-pack PR template** with checklist + provenance section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)