### PR TITLE
feat(skills): browsable pack index in skills/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ flowchart TB
 ## Community
 
 - **[Discord](https://discord.gg/fT7Ecbyq)** — join the build-in-public chat.
-- **[GitHub Discussions](https://github.com/ngoanpv/DeepInterview/discussions)** — questions, ideas, language-pack requests.
+- **[GitHub Discussions](https://github.com/ngoanpv/DeepInterview/discussions)** — questions, ideas, language-pack and playbook requests.
 - **[Issues](https://github.com/ngoanpv/DeepInterview/issues)** — bugs & features (templates provided).
+- **[The playbook library](skills/README.md)** — browsable interview question-bank packs that directly shape the AI's questions; contributions welcome ([#38](https://github.com/ngoanpv/DeepInterview/issues/38)).
 
 Built in the open. We respond to issues — ghosting contributors is the #1 cause of OSS death, and we don't intend to.
 

--- a/apps/agent/src/deepinterview_agent/skilllib/gen_index.py
+++ b/apps/agent/src/deepinterview_agent/skilllib/gen_index.py
@@ -1,0 +1,92 @@
+"""Regenerate the pack-index table in ``skills/README.md``.
+
+The index makes the library browsable on GitHub without cloning — a hub only
+grows if its shelves are visible. Deterministic output (raw ``confidence``,
+not the runtime-decayed value) so regenerating without pack changes is a
+no-op and the committed file never churns.
+
+Run from the repo root::
+
+    uv --directory apps/agent run python -m deepinterview_agent.skilllib.gen_index
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .models import Skill
+from .store import DEFAULT_SKILLS_DIR, _is_skill_file, load_skill
+
+START_MARKER = "<!-- PACK-INDEX:START — generated, do not edit by hand -->"
+END_MARKER = "<!-- PACK-INDEX:END -->"
+
+_LEVEL_ORDER = {"intern": 0, "junior": 1, "mid": 2, "senior": 3, "staff": 4, "principal": 5}
+_QUESTION_RE = re.compile(r"^\s*-\s+\S", re.MULTILINE)
+
+
+def _question_count(body_md: str) -> int:
+    """Number of ``- `` items under the ``## Question bank`` section."""
+    parts = re.split(r"^##\s+Question bank\s*$", body_md, flags=re.IGNORECASE | re.MULTILINE)
+    if len(parts) < 2:
+        return 0
+    section = re.split(r"^##\s", parts[1], maxsplit=1, flags=re.MULTILINE)[0]
+    return len(_QUESTION_RE.findall(section))
+
+
+def _load_packs(skills_dir: Path) -> list[tuple[str, Skill]]:
+    packs: list[tuple[str, Skill]] = []
+    for path in sorted(skills_dir.glob("*.md")):
+        if not _is_skill_file(path):
+            continue
+        try:
+            packs.append((path.name, load_skill(path)))
+        except Exception:  # noqa: BLE001, S112 - unparseable files are the linter's job, not the index's
+            continue
+    return packs
+
+
+def render_index(skills_dir: Path | None = None) -> str:
+    """Render the Markdown table for every parseable pack in the live library."""
+    root = skills_dir or DEFAULT_SKILLS_DIR
+    packs = _load_packs(root)
+    packs.sort(
+        key=lambda item: (
+            item[1].frontmatter.company.lower() != "generic",  # generic packs first
+            item[1].frontmatter.company.lower(),
+            item[1].frontmatter.role,
+            _LEVEL_ORDER.get(item[1].frontmatter.level, 99),
+        )
+    )
+    lines = [
+        "| Pack | Company | Role | Level | Status | Confidence | Questions | Verified |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for filename, skill in packs:
+        fm = skill.frontmatter
+        lines.append(
+            f"| [{fm.id}](./{filename}) | {fm.company} | {fm.role} | {fm.level} "
+            f"| {fm.status} | {fm.confidence:.2f} | {_question_count(skill.body_md)} "
+            f"| {fm.last_verified} |"
+        )
+    return "\n".join(lines)
+
+
+def update_readme(skills_dir: Path | None = None) -> Path:
+    """Replace the block between the index markers in ``skills/README.md``."""
+    root = skills_dir or DEFAULT_SKILLS_DIR
+    readme = root / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    if START_MARKER not in text or END_MARKER not in text:
+        msg = f"{readme} is missing the pack-index markers; add them once by hand"
+        raise SystemExit(msg)
+    head, rest = text.split(START_MARKER, 1)
+    _, tail = rest.split(END_MARKER, 1)
+    new = f"{head}{START_MARKER}\n{render_index(root)}\n{END_MARKER}{tail}"
+    readme.write_text(new, encoding="utf-8")
+    return readme
+
+
+if __name__ == "__main__":
+    path = update_readme()
+    print(f"regenerated pack index in {path}")

--- a/apps/agent/tests/test_skilllib.py
+++ b/apps/agent/tests/test_skilllib.py
@@ -378,3 +378,39 @@ def test_propose_default_dir_writes_to_review_only(
 
     assert (tmp_path / REVIEW_SUBDIR / f"{draft.id}.md").exists()
     assert list(tmp_path.glob("*.md")) == [], "default branch must not write live skills"
+
+
+# --- pack index ---------------------------------------------------------------
+
+
+def test_render_index_lists_packs_and_counts_questions(tmp_path: Path) -> None:
+    from deepinterview_agent.skilllib.gen_index import render_index
+
+    save_skill(_sample_skill(), tmp_path / "examplecorp-backend-engineer-senior.md")
+    table = render_index(tmp_path)
+    assert "[examplecorp-backend-engineer-senior](./examplecorp-backend-engineer-senior.md)" in table
+    assert "| 1 |" in table  # one question-bank item in the sample body
+
+
+def test_update_readme_replaces_only_marker_block(tmp_path: Path) -> None:
+    from deepinterview_agent.skilllib.gen_index import (
+        END_MARKER,
+        START_MARKER,
+        update_readme,
+    )
+
+    save_skill(_sample_skill(), tmp_path / "examplecorp-backend-engineer-senior.md")
+    readme = tmp_path / "README.md"
+    readme.write_text(f"intro\n\n{START_MARKER}\nstale\n{END_MARKER}\n\noutro\n", encoding="utf-8")
+    update_readme(tmp_path)
+    text = readme.read_text(encoding="utf-8")
+    assert "stale" not in text
+    assert text.startswith("intro") and text.rstrip().endswith("outro")
+    assert "| Pack |" in text
+
+    # Missing markers is a hard, explained failure.
+    bare = tmp_path / "sub"
+    bare.mkdir()
+    (bare / "README.md").write_text("no markers", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        update_readme(bare)

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,23 @@ promoted from real interview runs (`{company} × {role} × {level}`).
 - Always attach provenance ("based on N reports, last verified Z"); company facts pass a
   human/LLM review gate to avoid compounding hallucinated claims.
 
+## Pack index
+
+<!-- PACK-INDEX:START — generated, do not edit by hand -->
+| Pack | Company | Role | Level | Status | Confidence | Questions | Verified |
+|---|---|---|---|---|---|---|---|
+| [generic-backend-engineer-senior](./generic-backend-engineer-senior.md) | generic | backend-engineer | senior | promoted | 0.50 | 7 | 2026-07-25 |
+| [generic-frontend-engineer-mid](./generic-frontend-engineer-mid.md) | generic | frontend-engineer | mid | promoted | 0.50 | 7 | 2026-07-25 |
+| [generic-software-engineer-junior](./generic-software-engineer-junior.md) | generic | software-engineer | junior | promoted | 0.50 | 7 | 2026-07-25 |
+| [examplecorp-backend-senior](./example-corp-backend-senior.md) | ExampleCorp | backend-engineer | senior | draft | 0.30 | 2 | 2026-06-08 |
+<!-- PACK-INDEX:END -->
+
+Regenerate after adding or editing packs:
+
+```bash
+uv --directory apps/agent run python -m deepinterview_agent.skilllib.gen_index
+```
+
 `example-corp-backend-senior.md` is a **fictional** sample showing the format.
 
 The `generic-*.md` packs are hand-curated, company-agnostic fallbacks (matched


### PR DESCRIPTION
Makes the library visible without cloning — the pack table (id, company, role, level, status, confidence, question count, verified date) is generated between markers in `skills/README.md` by `python -m deepinterview_agent.skilllib.gen_index`. Deterministic output so regenerating without pack changes never churns the file. Initial index committed (4 packs); main README's Community section now links the library and #38.

Note: touches a different region of `skills/README.md` than #41, so the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)