### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,3 +11,5 @@ license: Apache-2.0
 repository-code: "https://github.com/ngoanpv/DeepInterview"
 authors:
   - name: "The DeepInterview contributors"
+version: 0.1.0
+date-released: 2026-07-25

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ _(Changelog is intentionally pre-launch and honest — no "1,000 stars" or shipp
 
 ## Releases
 
-No tagged release yet — DeepInterview is pre-`v0.1`. Watch [Releases](https://github.com/ngoanpv/DeepInterview/releases) and the News section above. Citation metadata lives in [`CITATION.cff`](CITATION.cff).
+Current release: **[v0.1.0](https://github.com/ngoanpv/DeepInterview/releases/tag/v0.1.0)** (2026-07-25) — the first tagged milestone: the full prep → live voice interview → scoring → coach loop verified on real providers, uncapped billing-free OSS build, hardened API surface, and the community playbook library wired into the question planner. See [Releases](https://github.com/ngoanpv/DeepInterview/releases) for notes; citation metadata lives in [`CITATION.cff`](CITATION.cff).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-4338CA.svg)](apps/agent)
 [![pnpm](https://img.shields.io/badge/pnpm-workspace-4338CA.svg)](pnpm-workspace.yaml)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/fT7Ecbyq)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-4338CA.svg)](CONTRIBUTING.md)
 
 **UI in English + Tiếng Việt · voice interviews in 7 languages incl. Vietnamese (more as packs land) · no sign-in required to self-host**
 
 [Why](#why-deepinterview) · [Features](#features) · [Quickstart](#quickstart) · [Architecture](#architecture) · [Community](#community) · [Contributing](#contributing)
+
+**Contributions wanted** — [interview question-bank packs](https://github.com/ngoanpv/DeepInterview/issues/38) · [language packs & provider adapters](docs/GOOD_FIRST_ISSUES.md) · your packs get asked in real interviews, and no API keys are needed to develop.
 
 </div>
 

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepinterview-agent"
-version = "0.0.0"
+version = "0.1.0"
 description = "DeepInterview live voice interviewer + prep/post pipelines (WP-0 shell)."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "deepinterview-agent"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/web",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepinterview",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Open-source (Apache-2.0), voice-first AI mock-interview platform. English-first, multilingual.",
   "license": "Apache-2.0",

--- a/packages/ee/package.json
+++ b/packages/ee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/ee",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Open-core extension seam — inert OSS defaults; downstream distributions replace this package's contents.",
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/shared",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/services/lightrag/pyproject.toml
+++ b/services/lightrag/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepinterview-lightrag"
-version = "0.0.0"
+version = "0.1.0"
 description = "DeepInterview knowledge sidecar — NaiveRAG by default, LightRAG + RAG-Anything + bge-m3 as an optional extra (WP-8)."
 license = "Apache-2.0"
 requires-python = ">=3.11"


### PR DESCRIPTION
First tagged release. Bumps every workspace version 0.0.0 → 0.1.0 (JS packages + agent + lightrag pyprojects), adds `version`/`date-released` to CITATION.cff, and points the README Releases section at the v0.1.0 tag. Tag + GitHub Release follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)