### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,5 +11,5 @@ license: Apache-2.0
 repository-code: "https://github.com/ngoanpv/DeepInterview"
 authors:
   - name: "The DeepInterview contributors"
-version: 0.1.0
+version: 0.2.0
 date-released: 2026-07-25

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _(Changelog is intentionally pre-launch and honest — no "1,000 stars" or shipp
 
 ## Releases
 
-Current release: **[v0.1.0](https://github.com/ngoanpv/DeepInterview/releases/tag/v0.1.0)** (2026-07-25) — the first tagged milestone: the full prep → live voice interview → scoring → coach loop verified on real providers, uncapped billing-free OSS build, hardened API surface, and the community playbook library wired into the question planner. See [Releases](https://github.com/ngoanpv/DeepInterview/releases) for notes; citation metadata lives in [`CITATION.cff`](CITATION.cff).
+Current release: **[v0.2.0](https://github.com/ngoanpv/DeepInterview/releases/tag/v0.2.0)** (2026-07-25) — the full prep → live voice interview → scoring → coach loop verified on real providers, uncapped billing-free OSS build, hardened API surface, and the community playbook library wired into the question planner. See [Releases](https://github.com/ngoanpv/DeepInterview/releases) for notes; citation metadata lives in [`CITATION.cff`](CITATION.cff).
 
 ## Features
 

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepinterview-agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "DeepInterview live voice interviewer + prep/post pipelines (WP-0 shell)."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepinterview",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Open-source (Apache-2.0), voice-first AI mock-interview platform. English-first, multilingual.",
   "license": "Apache-2.0",

--- a/packages/ee/package.json
+++ b/packages/ee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/ee",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Open-core extension seam — inert OSS defaults; downstream distributions replace this package's contents.",
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/shared",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/services/lightrag/pyproject.toml
+++ b/services/lightrag/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepinterview-lightrag"
-version = "0.1.0"
+version = "0.2.0"
 description = "DeepInterview knowledge sidecar — NaiveRAG by default, LightRAG + RAG-Anything + bge-m3 as an optional extra (WP-8)."
 license = "Apache-2.0"
 requires-python = ">=3.11"


### PR DESCRIPTION
Follow-up to #44: a `v0.1.0` tag already existed (2026-06-24, pre-billing-removal era), so this release ships as **v0.2.0** — all version stamps, CITATION.cff, and the README Releases pointer updated. Tag + GitHub Release follow on merge; the June v0.1.0 tag stays as history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)