### PR TITLE
docs: accuracy pass — env-keys list, contributor ask, verification date, Next 16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ pnpm + Turborepo. The TS **web** and Python **agent** are co-equal runtimes that
 | Path | What it owns | Language |
 |---|---|---|
 | `packages/shared` | **The contract.** `InterviewContext`, `QuestionPlan`, `ScoreCard`, REST + room contracts. TS source of truth, mirrored as Pydantic. **Build first; change carefully.** | TS (Zod) |
-| `apps/web` | UI, auth, CV upload, LiveKit token endpoint, all screens (`/setup`, `/interview/[id]`, `/report/[id]`, `/prep`). Knows nothing about LLM/STT/TTS. | Next.js 15 / React 19 / TS |
+| `apps/web` | UI, auth, CV upload, LiveKit token endpoint, all screens (`/setup`, `/interview/[id]`, `/report/[id]`, `/prep`). Knows nothing about LLM/STT/TTS. | Next.js 16 / React 19 / TS |
 | `apps/agent` | The live voice loop + LangGraph prep/post pipelines + avatar render util + skill distiller. Provider **adapters** live in `core/adapters/`. | Python 3.11 (uv) |
 | `services/lightrag` | LightRAG + RAG-Anything knowledge sidecar (Docker, `:9621`) for the Prep Coach. | Python (Docker) |
 | `cli/` | The `deepinterview` CLI / first-run init wizard — the adoption lever. | TS (tsup) |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pnpm deepinterview init    # or: cp .env.example .env  (keys are optional — se
 docker compose up --build  # web (:3000) + agent API (:8000) + lightrag (:9621)
 ```
 
-> **Status (verified June 2026, Docker 29 / Compose v5):** all images build and the three base services come up **healthy with zero keys** — the agent runs the full prep → plan → score loop on mock adapters, and http://localhost:3000 works offline.
+> **Status (verified July 2026, Docker 29 / Compose v5):** all images build and the three base services come up **healthy with zero keys** — the agent runs the full prep → plan → score loop on mock adapters, and http://localhost:3000 works offline.
 >
 > - **Docker reads the repo-root `.env`** (compose `env_file`). Local dev (`pnpm dev`) instead reads `apps/agent/.env` and `apps/web/.env.local` — keys there are **not** visible to the containers, so put them in the root `.env` for Docker.
 > - The **live voice worker** is opt-in: `docker compose --profile live up`. It **requires** `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` (plus STT/TTS/LLM keys) in the root `.env`; without them the worker exits and restart-loops while the base stack keeps running.
@@ -80,7 +80,7 @@ The button deploys **`apps/web`** to Vercel. The Python **agent** is not serverl
 
 <details><summary>Configuring providers & adding a language pack</summary>
 
-- **Keys** live in `.env` only (never committed). See [`.env.example`](.env.example) for the full list (LiveKit, Supabase, R2, STT/TTS/LLM, Tavily/Exa, payments, observability).
+- **Keys** live in `.env` only (never committed). See [`.env.example`](.env.example) for the full list (LiveKit, Supabase, R2, STT/TTS/LLM, Tavily/Exa, observability).
 - **Provider choice** is per-component: set `STT_PROVIDER`, `TTS_PROVIDER`, `LLM_PROVIDER` and the matching key. With no keys set, the agent falls back to **mock adapters** so everything still runs offline.
 - **Languages** are pluggable packs. UI strings live in `apps/web/lib/i18n/messages/` (EN + VI shipped); each planned question's `text` is a `LocalizedText` map (`text.en` / `text.vi` / …) alongside a `language_mode`.
 
@@ -187,7 +187,7 @@ Built in the open, with [Claude Code](https://claude.com/claude-code) as a heavi
 
 ## Contributing
 
-We'd love your help — especially **language packs**, **provider adapters**, and **accessibility**. Start with:
+We'd love your help — especially **interview question-bank packs** ([#38](https://github.com/ngoanpv/DeepInterview/issues/38)), **language packs**, **provider adapters**, and **accessibility**. Start with:
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — dev setup, the monorepo map, the work-package model, the provider-adapter (mock-first) pattern, and how to run **offline with no keys**.
 - [Good first issues](docs/GOOD_FIRST_ISSUES.md) — concrete, scoped tasks drawn from real gaps.


### PR DESCRIPTION
Four-line fix from the content review: drop the stale "payments" from the .env.example key list (billing left OSS in #34), lead the Contributing ask with question-bank packs (consistent with the hero), bump the compose verification date to July 2026 (re-verified today), and correct CONTRIBUTING's monorepo map to Next.js 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)