### PR TITLE
docs: CHANGELOG.md + News cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes, newest first. The README's [News](README.md#news) section
+carries the latest handful of entries; everything lands here permanently.
+Tagged releases: [GitHub Releases](https://github.com/ngoanpv/DeepInterview/releases).
+
+## v0.2.0 — 2026-07-25
+
+- **Gemini 3.6 Flash + LiveKit Agents 1.6.** Prep and scoring run on Gemini 3.6
+  Flash; the live voice stack moved to livekit-agents 1.6 (Gemini 3-ready
+  function calling on the turn path), and live captions read as one paragraph
+  per speaker instead of per-fragment lines.
+- **The community playbook library is live.** Question-bank packs in `skills/`
+  are retrieved by role/level and injected into the question planner — packs
+  the community writes get asked in real interviews. Ships with generic
+  backend/frontend/SWE packs, `deepinterview skills lint`, a pack PR template,
+  a content policy, and a browsable pack index.
+- **The open-source build is fully uncapped — billing removed.** Self-host with
+  your own keys: no plan gates, no interview caps, no billing tables. Payments
+  live only in the hosted edition.
+- **Hardening release.** Opt-in shared-secret auth for the agent API and
+  knowledge sidecar, locked-down Supabase row policies, and periodic transcript
+  checkpointing so a killed process loses seconds of an interview, not all of it.
+- **The study coach grounds answers in *your* session.** Prep ingests the CV,
+  JD, and company research into the knowledge sidecar keyed by session — coach
+  answers cite your own materials.
+- New logo family (outlined geometry — renders identically everywhere), README
+  restructure (quickstart first), and first-contributor infrastructure
+  (protected `main`, Discussions, issue templates for packs and code execution).
+
+## v0.1.0 — 2026-06-24
+
+- **Live voice interviews run on real providers.** The full loop — personalized
+  prep (real Gemini CV/JD analysis + company research) → real-time voice
+  interview on LiveKit (Deepgram STT · Gemini · Cartesia/ElevenLabs TTS) →
+  scored report — runs end to end, with semantic end-of-turn detection and
+  noise-robust, word-gated barge-in.
+- **`docker compose up` verified.** All images build; the base stack (web +
+  agent API + knowledge sidecar) comes up healthy with zero keys on mock
+  adapters; `--profile live` adds the voice worker.
+- **Relicensed to Apache 2.0** — permissive core, bring-your-own keys, no sign-in.
+- Early build: cross-language `InterviewContext` contract (TS ↔ Pydantic)
+  round-trips; prep/live/post pipelines and all web screens run offline with
+  mock adapters.

--- a/README.md
+++ b/README.md
@@ -126,11 +126,9 @@ Practicing in your head (or in a text chat) isn't how interviews work. DeepInter
 > - **[2026.07]** **The study coach now grounds answers in *your* session.** Prep ingests your CV, the JD, and company research into the knowledge sidecar keyed by session — coach answers cite your own materials, not generic tips.
 > - **[2026.06]** **Live voice interviews run on real providers.** The full loop — personalized prep (real Gemini CV/JD analysis + company research) → real-time voice interview on LiveKit (Deepgram STT · Gemini · Cartesia/ElevenLabs TTS) → scored report — now runs end to end, with semantic end-of-turn detection and noise-robust, word-gated barge-in.
 > - **[2026.06]** **`docker compose up` verified.** All images build; the base stack (web + agent API + knowledge sidecar) comes up healthy with **zero keys** on mock adapters; `--profile live` adds the voice worker.
-> - **[2026.06]** **Relicensed to Apache 2.0** — permissive core, bring-your-own keys, no sign-in.
-> - **[2026.06]** Early build: cross-language `InterviewContext` contract (TS ↔ Pydantic) round-trips; prep/live/post pipelines and all web screens run offline with mock adapters.
 > - **[next]** The hero demo GIF, hosted live demo, and more language packs.
 
-_(Changelog is intentionally pre-launch and honest — no "1,000 stars" or shipped-feature claims until they're true.)_
+_(Honest by policy — no shipped-feature claims until they're true. Older entries roll into [CHANGELOG.md](CHANGELOG.md).)_
 
 ## Releases
 


### PR DESCRIPTION
Growth-plan B2: permanent changelog (organized by release, seeded from the full News history) and the README News section capped at its six freshest entries with a rollover link. Keeps the freshness signal tight as entries accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)