### PR TITLE
feat: add professor persona (Dr. Chen) to avatar gallery

### DIFF
--- a/apps/web/components/avatar/avatar-stage.tsx
+++ b/apps/web/components/avatar/avatar-stage.tsx
@@ -57,6 +57,11 @@ const FALLBACK_STYLE: Record<
     glow: "radial-gradient(120% 90% at 50% 18%, rgba(120,140,130,0.20), transparent 60%)",
     accent: "#4a6b5d",
   },
+  professor: {
+    gradient: "linear-gradient(165deg, #f9f6f0 0%, #f0ece2 55%, #e8e4da 100%)",
+    glow: "radial-gradient(120% 90% at 50% 18%, rgba(160,140,100,0.20), transparent 60%)",
+    accent: "#7a6b42",
+  },
 };
 
 type LayerStatus = "loading" | "ready" | "error";

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -15,7 +15,7 @@
  */
 
 /** Stable persona ids used across the pipeline and the Veo render scripts. */
-export type PersonaId = "anime" | "superhero" | "recruiter";
+export type PersonaId = "anime" | "superhero" | "recruiter" | "professor";
 
 export interface Persona {
   /** Stable id sent through the interview pipeline. */
@@ -56,6 +56,14 @@ export const PERSONAS: Persona[] = [
     poster_url: "/avatars/recruiter.jpg",
     idle_url: "/avatars/recruiter-idle.mp4",
     speaking_url: "/avatars/recruiter-speaking.mp4",
+  },
+  {
+    id: "professor",
+    name: "Dr. Chen",
+    style: "Calm, thoughtful academic who probes deeply and values precision.",
+    poster_url: "/avatars/professor.jpg",
+    idle_url: "/avatars/professor-idle.mp4",
+    speaking_url: "/avatars/professor-speaking.mp4",
   },
 ];
 

--- a/scripts/veo/prompts.ts
+++ b/scripts/veo/prompts.ts
@@ -25,7 +25,7 @@
 
 /** Mirrors `PersonaId` in apps/web/lib/personas.ts — kept local to avoid an
  * `@/` import that wouldn't resolve outside the web package. */
-export type PersonaId = "anime" | "superhero" | "recruiter";
+export type PersonaId = "anime" | "superhero" | "recruiter" | "professor";
 
 export interface VeoPromptSet {
   /** Prompt for the single reference still (first frame of both loops). */
@@ -66,7 +66,13 @@ export const VEO_PROMPTS: Record<PersonaId, VeoPromptSet> = {
     idle: `Medium close-up, photorealistic. A fictional professional male recruiter, late thirties, short tidy hair, light beard, navy blazer over white shirt, warm approachable expression, not resembling any real person. Subtle breathing, natural blinking, slight head movement. Clean light-grey office-studio background with soft bokeh, soft three-point lighting, warm key from left. No dialogue, quiet office ambience. Static camera. First frame matches last frame for a seamless loop. ${IP_RULE}`,
     speaking: `Same fictional male recruiter — same blazer, hair, background, soft three-point lighting, medium close-up. Speaks in a warm professional manner to camera, natural lip movement, occasional reassuring nods and a small open-hand gesture, attentive expression. No specific dialogue audio, quiet office ambience. Static camera. First frame matches last frame for a seamless loop. ${IP_RULE}`,
   },
+  // (d) Academic / professor
+  professor: {
+    reference: `Medium close-up, photorealistic. A fictional female academic professor, mid-forties, round glasses, shoulder-length grey-streaked hair, tweed blazer over a collared shirt, thoughtful calm expression, eyeline to camera, not resembling any real person. Warm wood-panelled study background with bookshelves out of focus, soft warm library lighting. Static camera. ${IP_RULE}`,
+    idle: `Medium close-up, photorealistic. A fictional female academic professor, mid-forties, round glasses, shoulder-length grey-streaked hair, tweed blazer over a collared shirt, thoughtful calm expression. Subtle breathing, natural blinking, slight nod. Warm wood-panelled study background with bookshelves out of focus, soft warm library lighting. No dialogue, quiet room tone. Static camera. First frame matches last frame for a seamless loop. ${IP_RULE}`,
+    speaking: `Same fictional female professor — same glasses, blazer, hair, warm study background, medium close-up. Speaks in a measured, thoughtful manner to camera, precise lip movement, occasional raised eyebrow or small gesture like pointing for emphasis, engaged scholarly expression. No specific dialogue audio, quiet ambience. Static camera. First frame matches last frame for a seamless loop. ${IP_RULE}`,
+  },
 };
 
 /** Ordered list of persona ids for CLI iteration. */
-export const PERSONA_IDS: PersonaId[] = ["anime", "superhero", "recruiter"];
+export const PERSONA_IDS: PersonaId[] = ["anime", "superhero", "recruiter", "professor"];


### PR DESCRIPTION
## Summary

Adds a 4th avatar persona — **Dr. Chen**, a calm academic professor — following the established pattern for anime/superhero/recruiter.

## Changes

| File | Change |
|------|--------|
| `apps/web/lib/personas.ts` | `PersonaId` type union + `PERSONAS` array entry |
| `scripts/veo/prompts.ts` | `PersonaId` type + `VEO_PROMPTS` (reference/idle/speaking) + `PERSONA_IDS` |
| `apps/web/components/avatar/avatar-stage.tsx` | Gradient/glow/accent fallback styling |

## IP safety

All three Veo prompts carry the standard IP-safe clause: *"original fictional character, not resembling any real person or existing franchise; no brand logos."*

## Verification

```
pnpm typecheck  — 6/6 tasks successful
```

Fixes #53