### PR TITLE
feat(avatars): vendor-neutral avatar packs — bring your own generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ CLAUDE.md
 
 # Supabase CLI local state (project ref, pooler URL)
 supabase/.temp/
+
+# Avatar media is never committed (docs/AVATARS.md): local-dev drop-in only;
+# accepted packs are published as GitHub Release artifacts + CDN.
+apps/web/public/avatars/

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Practicing in your head (or in a text chat) isn't how interviews work. DeepInter
 - **Community playbook library** — question-bank packs in [`skills/`](skills/) (versioned Markdown + YAML) are retrieved by role/level and injected into the Question Planner: packs the community writes get asked in real interviews. Validate yours with `pnpm deepinterview skills lint`.
 - **Scored feedback** — a rubric-based evaluator + language coach write a per-competency `ScoreCard` with strengths, gaps, model answers, and next steps that map straight back to the questions you were asked.
 - **Prep Coach** *(in progress)* — turns your gaps into an LLM study loop (plan → drills → Socratic chat). Grounded + cited answers are **optional**: set `LIGHTRAG_URL` (or wire a managed RAG behind the same adapter) to ground responses in your own uploaded materials; by default the coach answers honestly without fabricated citations.
-- **Cost-smart avatars** *(in progress)* — the crossfade system + persona fallbacks are built; pre-rendered **Veo 3.1** idle/speaking loops drop in as the assets land (until then it renders a calm gradient stage). Original anime / superhero / recruiter personas (no named IP), so runtime cost is **CDN-only — no per-minute avatar fees**.
+- **Cost-smart avatars** *(in progress)* — the crossfade system + persona fallbacks are built; pre-rendered idle/speaking loops from **any video generator** drop in as packs land ([docs/AVATARS.md](docs/AVATARS.md) — until then it renders a calm gradient stage). Original personas only (no named IP), so runtime cost is **CDN-only — no per-minute avatar fees**.
 
 ## Provider matrix
 

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -30,6 +30,9 @@ export interface Persona {
   idle_url: string;
   /** Speaking loop (talking mouth, nods, gestures). Placeholder. */
   speaking_url: string;
+  /** Optional contribution credit, e.g. "rendered by @user with Sora 2".
+   * Shown in the avatar gallery / release notes (see docs/AVATARS.md). */
+  credit?: string;
 }
 
 export const PERSONAS: Persona[] = [

--- a/docs/AVATARS.md
+++ b/docs/AVATARS.md
@@ -1,0 +1,61 @@
+# Avatar packs — bring your own generator
+
+The interviewer avatars are **pre-rendered video loops** crossfaded by agent
+state at runtime (`<AvatarStage>`), so runtime cost is ~$0/min — just CDN
+bytes. The app never calls a video vendor: it plays whatever assets exist.
+That means avatar packs can be produced with **any generator** — Veo, Sora,
+Runway, Kling, a local ComfyUI/LTX rig, or hand animation. There is no
+blessed vendor; there is a **contract**.
+
+Avatar packs are **curated artifacts, not build outputs**: video generation is
+non-deterministic, so the committed prompt is provenance, not a reproducible
+build recipe. Packs go through human review like any contribution.
+
+Assets are always optional: with no assets present the app renders its calm
+gradient stage (the mock-first rule applies to pixels too). Nothing may break
+when a pack is missing.
+
+## What a pack contains
+
+For one persona (see `apps/web/lib/personas.ts` for the ids):
+
+| Deliverable | Contract |
+|---|---|
+| Reference still (poster) | JPG/PNG, ≥1024px wide — the character's canonical look; visually the first frame of the loops |
+| Idle loop | MP4 (H.264), ~8s, **first frame = last frame** (seamless), subtle breathing/blinking, no audio track |
+| Speaking loop | MP4 (H.264), ~8s, seamless, same character/framing/background as idle, natural mouth movement + small gestures, no audio track |
+
+Shared requirements: medium close-up, calm uncluttered background, static
+camera, the **same character** across all three files, ≤25 MB per file.
+
+## The IP-safety checklist (load-bearing — every pack, no exceptions)
+
+- [ ] Original fictional character — resembles **no real person** (including
+      the contributor) and **no existing franchise/character**
+- [ ] No brand logos, trademarks, or copyrighted set dressing
+- [ ] **Generator + full prompt disclosed** in the PR (AI-generated content
+      must be labeled as such; the prompt is the reviewable recipe)
+- [ ] Contributor affirms they hold/grant rights to the output under the
+      project license and that the generator's terms permit this use
+
+Packs that can't credibly tick every box are declined — same bar as the
+question-bank content policy in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## How to contribute a pack
+
+1. **Open a PR** with the persona entry (or a new persona following the
+   [#53](https://github.com/ngoanpv/DeepInterview/issues/53) pattern), the
+   generation prompt(s), and the checklist above — plus the rendered files
+   **attached to the PR or linked** (release, Drive, etc.).
+2. **Binaries never enter git history.** Do not commit media; `apps/web/
+   public/avatars/` is gitignored as a local-dev drop-in only.
+3. On acceptance, a maintainer publishes the files as **GitHub Release
+   artifacts** (fork-survivable, archived) and to the CDN, then updates the
+   persona's `poster_url` / `idle_url` / `speaking_url` and your `credit`
+   line ("rendered by @you with <generator>").
+
+## Reference implementation
+
+`scripts/veo/` renders packs with Google Veo 3.1 if you have a Gemini API
+key — it is **one way** to satisfy this contract, not the way. Model ids in
+that script chase a moving vendor; the contract above does not.

--- a/scripts/veo/README.md
+++ b/scripts/veo/README.md
@@ -1,4 +1,9 @@
-# Veo 3.1 avatar render (WP-9)
+# Veo 3.1 avatar render — reference implementation (WP-9)
+
+> **One way, not the way.** Avatar packs can be produced with any generator —
+> the vendor-neutral contract, IP checklist, and submission flow live in
+> [`docs/AVATARS.md`](../../docs/AVATARS.md). This script satisfies that
+> contract with Google Veo 3.1 for anyone holding a Gemini API key.
 
 One-time pipeline that turns the IP-safe prompts in `prompts.ts` into the
 pre-rendered idle/speaking loops the web app crossfades in `<AvatarStage>`.

--- a/scripts/veo/render.mjs
+++ b/scripts/veo/render.mjs
@@ -240,6 +240,15 @@ async function liveRender(personas, model, apiKey) {
       ? await sdkGenerateImage(genai, apiKey, p.reference)
       : await restGenerateImage(apiKey, p.reference);
 
+    // Save the still too — it doubles as the gallery poster (personas.ts
+    // poster_url) and makes re-runs auditable.
+    if (referenceImage?.imageBytes) {
+      const ext = /jpe?g/.test(referenceImage.mimeType || "") ? "jpg" : "png";
+      const stillPath = resolve(OUT_DIR, `${id}.${ext}`);
+      await writeFile(stillPath, Buffer.from(referenceImage.imageBytes, "base64"));
+      console.log(`    wrote ${stillPath}`);
+    }
+
     // Steps 2 & 3: idle + speaking loops from the same first frame.
     for (const kind of ["idle", "speaking"]) {
       console.log(`  Rendering ${kind} loop (8s, seamless)…`);
@@ -284,7 +293,7 @@ async function sdkGenerateImage(genai, apiKey, prompt) {
   const { GoogleGenAI } = genai;
   const ai = new GoogleGenAI({ apiKey });
   const res = await ai.models.generateImages({
-    model: "imagen-3.0-generate-002",
+    model: "gemini-3-pro-image",
     prompt,
     config: { numberOfImages: 1 },
   });
@@ -317,23 +326,24 @@ async function sdkGenerateVideo(genai, apiKey, model, prompt, referenceImage) {
 const REST_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 async function restGenerateImage(apiKey, prompt) {
-  // Imagen predict endpoint returns base64 bytes.
+  // Gemini-native image generation (Imagen predict is closed to new users).
   const res = await fetch(
-    `${REST_BASE}/models/imagen-3.0-generate-002:predict?key=${apiKey}`,
+    `${REST_BASE}/models/gemini-3-pro-image:generateContent?key=${apiKey}`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        instances: [{ prompt }],
-        parameters: { sampleCount: 1 },
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { responseModalities: ["IMAGE"] },
       }),
     },
   );
-  if (!res.ok) throw new Error(`Imagen REST error ${res.status}: ${await res.text()}`);
+  if (!res.ok) throw new Error(`Image REST error ${res.status}: ${await res.text()}`);
   const json = await res.json();
-  const b64 = json?.predictions?.[0]?.bytesBase64Encoded;
+  const part = json?.candidates?.[0]?.content?.parts?.find((p) => p.inlineData);
+  const b64 = part?.inlineData?.data;
   if (!b64) throw new Error("No reference image bytes returned by REST.");
-  return { imageBytes: b64, mimeType: "image/png" };
+  return { imageBytes: b64, mimeType: part.inlineData.mimeType || "image/png" };
 }
 
 async function restGenerateVideo(apiKey, model, prompt, referenceImage) {
@@ -369,10 +379,23 @@ async function restGenerateVideo(apiKey, model, prompt, referenceImage) {
     op = await poll.json();
   }
 
-  const uri =
-    op?.response?.generateVideoResponse?.generatedSamples?.[0]?.video?.uri;
-  if (!uri) throw new Error("No video URI in REST response.");
-  const dl = await fetch(`${uri}&key=${apiKey}`);
+  // The operation response shape has drifted across Veo releases — accept
+  // every known variant, and dump the payload when none match so the next
+  // drift is diagnosable without re-spending a render.
+  const sample =
+    op?.response?.generateVideoResponse?.generatedSamples?.[0] ??
+    op?.response?.generatedVideos?.[0] ??
+    op?.response?.videos?.[0];
+  const uri = sample?.video?.uri ?? sample?.uri;
+  const inline = sample?.video?.encodedVideo ?? sample?.bytesBase64Encoded;
+  if (inline) return Buffer.from(inline, "base64");
+  if (!uri) {
+    throw new Error(
+      `No video URI in REST response. Operation payload:\n${JSON.stringify(op, null, 2).slice(0, 4000)}`,
+    );
+  }
+  const sep = uri.includes("?") ? "&" : "?";
+  const dl = await fetch(`${uri}${sep}key=${apiKey}`);
   if (!dl.ok) throw new Error(`Veo download error ${dl.status}`);
   return Buffer.from(await dl.arrayBuffer());
 }


### PR DESCRIPTION
Design discussed with the maintainer: the runtime is already vendor-neutral (it just plays MP4s), so avatar contribution becomes **spec + any generator + reviewed output** instead of a Veo-locked, credits-gated maintainer chore.

- **docs/AVATARS.md** — pack contract (poster + idle + speaking, seamless loops, same character), IP-safety checklist enforced on the output, AI-content disclosure + provenance requirement, curated-artifact framing, and the submission flow (assets via PR attachment/link → maintainer publishes to **GitHub Releases + CDN**; binaries never in git history; `public/avatars/` gitignored as local drop-in).
- **`credit` field** on personas for contributor recognition.
- **scripts/veo/ becomes the reference implementation**, with today's fixes: current image model (imagen closed to new users → `gemini-3-pro-image`), hardened Veo operation-response parsing, stills saved as posters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)