### PR TITLE
feat(cli): avatars pull/verify + hash-pinned asset manifest

### DIFF
--- a/avatars.manifest.json
+++ b/avatars.manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "release": "https://github.com/ngoanpv/DeepInterview/releases",
+  "packs": []
+}

--- a/cli/src/commands/avatars.ts
+++ b/cli/src/commands/avatars.ts
@@ -1,0 +1,132 @@
+/**
+ * `deepinterview avatars pull`            — fetch + SHA-256-verify accepted packs
+ * `deepinterview avatars verify <files…>` — contributor pre-flight on local files
+ *
+ * The manifest (repo-root `avatars.manifest.json`) is the source of truth for
+ * what ships; assets land in the gitignored `apps/web/public/avatars/`. The
+ * app renders its gradient fallback when files are absent, so `pull` is always
+ * optional. See docs/AVATARS.md.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import {
+  checkFileBytes,
+  parseManifest,
+  sha256Hex,
+  type AvatarManifest,
+} from "../lib/avatar-manifest";
+
+const MANIFEST_PATH = "avatars.manifest.json";
+const DEST_DIR = join("apps", "web", "public", "avatars");
+
+async function loadManifest(): Promise<AvatarManifest> {
+  if (!existsSync(MANIFEST_PATH)) {
+    throw new Error(
+      `${MANIFEST_PATH} not found — run from the repo root (pnpm deepinterview avatars pull).`,
+    );
+  }
+  return parseManifest(await readFile(MANIFEST_PATH, "utf8"));
+}
+
+async function pull(): Promise<void> {
+  const manifest = await loadManifest();
+  const files = manifest.packs.flatMap((p) =>
+    p.files.map((f) => ({ ...f, persona: p.persona })),
+  );
+  if (files.length === 0) {
+    console.log("Manifest has no published packs yet — nothing to pull.");
+    console.log(
+      "The app renders its gradient avatar stage until packs land (docs/AVATARS.md).",
+    );
+    return;
+  }
+  await mkdir(DEST_DIR, { recursive: true });
+
+  let fetched = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const file of files) {
+    const dest = join(DEST_DIR, file.name);
+    if (existsSync(dest)) {
+      const existing = sha256Hex(await readFile(dest));
+      if (existing === file.sha256) {
+        console.log(`  ok        ${file.name} (already verified)`);
+        skipped++;
+        continue;
+      }
+      console.log(
+        `  refetch   ${file.name} (local file does not match manifest)`,
+      );
+    }
+    try {
+      const res = await fetch(file.url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      const hash = sha256Hex(bytes);
+      if (hash !== file.sha256) {
+        throw new Error(
+          `SHA-256 mismatch (expected ${file.sha256.slice(0, 12)}…, got ${hash.slice(0, 12)}…)`,
+        );
+      }
+      await writeFile(dest, bytes);
+      console.log(
+        `  fetched   ${file.name} (${(bytes.byteLength / 1024 / 1024).toFixed(1)} MB, verified)`,
+      );
+      fetched++;
+    } catch (cause) {
+      await rm(dest, { force: true });
+      console.error(`  FAILED    ${file.name}: ${String(cause)}`);
+      failed++;
+    }
+  }
+  console.log(
+    `\n${fetched} fetched, ${skipped} already verified, ${failed} failed → ${DEST_DIR}/`,
+  );
+  if (failed > 0) process.exitCode = 1;
+}
+
+async function verify(paths: string[]): Promise<void> {
+  if (paths.length === 0) {
+    console.error(
+      "Usage: deepinterview avatars verify <file.mp4|file.jpg> […]",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  let errors = 0;
+  for (const path of paths) {
+    let bytes: Uint8Array;
+    try {
+      bytes = await readFile(path);
+    } catch (cause) {
+      console.error(`  error     ${path}: cannot read (${String(cause)})`);
+      errors++;
+      continue;
+    }
+    const issues = checkFileBytes(basename(path), bytes);
+    const fileErrors = issues.filter((i) => i.level === "error");
+    errors += fileErrors.length;
+    const verdict = fileErrors.length > 0 ? "error" : "ok";
+    console.log(
+      `  ${verdict.padEnd(9)} ${basename(path)}  sha256=${sha256Hex(bytes)}`,
+    );
+    for (const issue of issues)
+      console.log(`            ${issue.level}: ${issue.message}`);
+  }
+  console.log(
+    errors > 0
+      ? "\nFix the errors above before submitting (contract: docs/AVATARS.md)."
+      : "\nTechnical contract OK. Paste the sha256 lines into your PR — a maintainer" +
+          "\nstill reviews the content itself (IP-safety checklist) before acceptance.",
+  );
+  if (errors > 0) process.exitCode = 1;
+}
+
+export async function runAvatars(args: string[]): Promise<void> {
+  const [sub, ...rest] = args;
+  if (sub === "pull") return pull();
+  if (sub === "verify") return verify(rest);
+  console.error("Usage: deepinterview avatars <pull | verify <files…>>");
+  process.exitCode = 1;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,3 +1,4 @@
+import { runAvatars } from "./commands/avatars";
 import { runInit } from "./commands/init";
 import { runSkills } from "./commands/skills";
 
@@ -15,6 +16,10 @@ Usage:
                                  (non-interactive)
   deepinterview skills lint      Validate skill packs in skills/ (frontmatter
                                  schema + conventions) before opening a PR
+  deepinterview avatars pull     Fetch published avatar packs (SHA-256 verified
+                                 against avatars.manifest.json)
+  deepinterview avatars verify   Pre-flight local avatar files before submitting
+                                 a pack (technical contract + hashes)
 
 \`init\` writes three files:
   .env                 → read by docker compose (the full stack)
@@ -34,6 +39,9 @@ async function main(): Promise<void> {
       break;
     case "skills":
       await runSkills(args);
+      break;
+    case "avatars":
+      await runAvatars(args);
       break;
     case undefined:
     case "help":

--- a/cli/src/lib/avatar-manifest.test.ts
+++ b/cli/src/lib/avatar-manifest.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_FILE_BYTES,
+  checkFileBytes,
+  parseManifest,
+  sha256Hex,
+} from "./avatar-manifest";
+
+const VALID = JSON.stringify({
+  version: 1,
+  release: "https://github.com/ngoanpv/DeepInterview/releases",
+  packs: [
+    {
+      persona: "recruiter",
+      credit: "rendered by @someone with Veo 3.1",
+      files: [
+        {
+          name: "recruiter-idle.mp4",
+          sha256: "a".repeat(64),
+          url: "https://github.com/ngoanpv/DeepInterview/releases/download/avatars-v1/recruiter-idle.mp4",
+        },
+      ],
+    },
+  ],
+});
+
+describe("parseManifest", () => {
+  it("accepts a valid manifest and an empty pack list", () => {
+    expect(parseManifest(VALID).packs[0]?.files[0]?.name).toBe(
+      "recruiter-idle.mp4",
+    );
+    expect(
+      parseManifest(
+        JSON.stringify({ version: 1, release: "https://x", packs: [] }),
+      ).packs,
+    ).toEqual([]);
+  });
+
+  it("rejects bad hashes, non-https urls, and unknown shapes", () => {
+    expect(() =>
+      parseManifest(VALID.replace("a".repeat(64), "nothex")),
+    ).toThrow(/sha256/);
+    expect(() =>
+      parseManifest(
+        VALID.replace(
+          "https://github.com/ngoanpv/DeepInterview/releases/download",
+          "http://github.com/ngoanpv/DeepInterview/releases/download",
+        ),
+      ),
+    ).toThrow(/https/);
+    expect(() =>
+      parseManifest('{"version":2,"release":"x","packs":[]}'),
+    ).toThrow(/version/);
+    expect(() => parseManifest("[]")).toThrow(/object/);
+    expect(() => parseManifest("{not json")).toThrow(/valid JSON/);
+  });
+
+  it("rejects non-kebab or wrong-extension filenames", () => {
+    expect(() =>
+      parseManifest(VALID.replace("recruiter-idle.mp4", "Recruiter Idle.mov")),
+    ).toThrow(/kebab-case/);
+  });
+});
+
+describe("checkFileBytes", () => {
+  const mp4 = new Uint8Array([0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70, 1, 2, 3]); // "ftyp"
+  const jpg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+
+  it("passes well-formed mp4 and jpeg bytes", () => {
+    expect(checkFileBytes("x-idle.mp4", mp4)).toEqual([]);
+    expect(checkFileBytes("x.jpg", jpg)).toEqual([]);
+  });
+
+  it("rejects file types outside the contract", () => {
+    expect(checkFileBytes("demo.gif", jpg)[0]?.message).toMatch(
+      /allowed avatar file type/,
+    );
+    expect(checkFileBytes("x.mov", mp4)[0]?.message).toMatch(
+      /allowed avatar file type/,
+    );
+  });
+
+  it("rejects wrong magic bytes, empty files, and oversize files", () => {
+    expect(checkFileBytes("x-idle.mp4", jpg)[0]?.message).toMatch(/ftyp/);
+    expect(checkFileBytes("x.jpg", mp4)[0]?.message).toMatch(/JPEG/);
+    expect(checkFileBytes("x.jpg", new Uint8Array(0))[0]?.message).toMatch(
+      /empty/,
+    );
+    const big = new Uint8Array(MAX_FILE_BYTES + 1);
+    big[0] = 0xff;
+    big[1] = 0xd8;
+    expect(checkFileBytes("x.jpg", big)[0]?.message).toMatch(/25 MB/);
+  });
+});
+
+describe("sha256Hex", () => {
+  it("matches a known vector", () => {
+    expect(sha256Hex(new Uint8Array(0))).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+});

--- a/cli/src/lib/avatar-manifest.ts
+++ b/cli/src/lib/avatar-manifest.ts
@@ -1,0 +1,146 @@
+/**
+ * Avatar pack manifest — the repo's tamper-evident ledger of accepted packs.
+ *
+ * `avatars.manifest.json` (repo root) pins every published avatar file to a
+ * SHA-256 recorded at acceptance (see docs/AVATARS.md). `avatars pull`
+ * downloads + verifies against it; `avatars verify` computes hashes and
+ * checks the technical contract for files about to be submitted. Pure
+ * parsing/validation lives here so it's unit-testable; commands do the I/O.
+ */
+import { createHash } from "node:crypto";
+
+export interface ManifestFile {
+  /** Filename as served from /avatars/, e.g. "recruiter-idle.mp4". */
+  name: string;
+  /** Lowercase hex SHA-256 of the exact accepted bytes. */
+  sha256: string;
+  /** Download URL (GitHub Release asset — maintainer-controlled hosting). */
+  url: string;
+}
+
+export interface ManifestPack {
+  /** Persona id (must match apps/web/lib/personas.ts). */
+  persona: string;
+  /** Contribution credit, e.g. "rendered by @user with Sora 2". */
+  credit?: string;
+  files: ManifestFile[];
+}
+
+export interface AvatarManifest {
+  version: 1;
+  release: string;
+  packs: ManifestPack[];
+}
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const NAME_RE = /^[a-z0-9-]+\.(mp4|jpg|jpeg|png)$/;
+
+/** Max bytes per avatar file (docs/AVATARS.md contract). */
+export const MAX_FILE_BYTES = 25 * 1024 * 1024;
+
+/** Parse + validate manifest JSON text. Throws with a precise message. */
+export function parseManifest(text: string): AvatarManifest {
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch (cause) {
+    throw new Error(
+      `avatars.manifest.json is not valid JSON: ${String(cause)}`,
+    );
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    throw new Error("manifest must be a JSON object");
+  }
+  const m = data as Record<string, unknown>;
+  if (m.version !== 1) throw new Error("manifest `version` must be 1");
+  if (typeof m.release !== "string")
+    throw new Error("manifest `release` must be a URL string");
+  if (!Array.isArray(m.packs))
+    throw new Error("manifest `packs` must be an array");
+  for (const pack of m.packs as Record<string, unknown>[]) {
+    if (typeof pack.persona !== "string" || pack.persona === "") {
+      throw new Error("every pack needs a non-empty `persona`");
+    }
+    if (pack.credit !== undefined && typeof pack.credit !== "string") {
+      throw new Error(
+        `pack "${pack.persona}": \`credit\` must be a string when present`,
+      );
+    }
+    if (!Array.isArray(pack.files) || pack.files.length === 0) {
+      throw new Error(
+        `pack "${pack.persona}": \`files\` must be a non-empty array`,
+      );
+    }
+    for (const f of pack.files as Record<string, unknown>[]) {
+      if (typeof f.name !== "string" || !NAME_RE.test(f.name)) {
+        throw new Error(
+          `pack "${pack.persona}": file name ${JSON.stringify(f.name)} must be kebab-case ` +
+            "with a .mp4/.jpg/.jpeg/.png extension",
+        );
+      }
+      if (typeof f.sha256 !== "string" || !SHA256_RE.test(f.sha256)) {
+        throw new Error(
+          `pack "${pack.persona}" file "${f.name}": \`sha256\` must be 64 hex chars`,
+        );
+      }
+      if (typeof f.url !== "string" || !/^https:\/\//.test(f.url)) {
+        throw new Error(
+          `pack "${pack.persona}" file "${f.name}": \`url\` must be https`,
+        );
+      }
+    }
+  }
+  return data as AvatarManifest;
+}
+
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export interface FileCheckIssue {
+  level: "error" | "warning";
+  message: string;
+}
+
+/** Technical-contract checks on raw file bytes (docs/AVATARS.md). */
+export function checkFileBytes(
+  name: string,
+  bytes: Uint8Array,
+): FileCheckIssue[] {
+  const issues: FileCheckIssue[] = [];
+  if (!/\.(mp4|jpg|jpeg|png)$/.test(name)) {
+    issues.push({
+      level: "error",
+      message:
+        "not an allowed avatar file type (contract: .mp4 loops, .jpg/.png poster)",
+    });
+    return issues;
+  }
+  if (bytes.byteLength === 0) {
+    issues.push({ level: "error", message: "file is empty" });
+    return issues;
+  }
+  if (bytes.byteLength > MAX_FILE_BYTES) {
+    issues.push({
+      level: "error",
+      message: `file is ${(bytes.byteLength / 1024 / 1024).toFixed(1)} MB — the contract caps files at 25 MB`,
+    });
+  }
+  if (/\.mp4$/.test(name)) {
+    // MP4 magic: bytes 4..8 spell "ftyp" in the first box header.
+    const ftyp = Buffer.from(bytes.slice(4, 8)).toString("ascii");
+    if (ftyp !== "ftyp") {
+      issues.push({
+        level: "error",
+        message: "not an MP4 container (missing ftyp header)",
+      });
+    }
+  }
+  if (/\.(jpg|jpeg)$/.test(name) && !(bytes[0] === 0xff && bytes[1] === 0xd8)) {
+    issues.push({ level: "error", message: "not a JPEG (bad magic bytes)" });
+  }
+  if (/\.png$/.test(name) && !(bytes[0] === 0x89 && bytes[1] === 0x50)) {
+    issues.push({ level: "error", message: "not a PNG (bad magic bytes)" });
+  }
+  return issues;
+}

--- a/docs/AVATARS.md
+++ b/docs/AVATARS.md
@@ -43,6 +43,9 @@ question-bank content policy in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## How to contribute a pack
 
+0. **Pre-flight locally**: `pnpm deepinterview avatars verify <your files>`
+   checks the technical contract (container, magic bytes, size budget) and
+   prints each file's SHA-256 to paste into the PR.
 1. **Open a PR** with the persona entry (or a new persona following the
    [#53](https://github.com/ngoanpv/DeepInterview/issues/53) pattern), the
    generation prompt(s), and the checklist above — plus the rendered files
@@ -62,6 +65,23 @@ question-bank content policy in [CONTRIBUTING.md](../CONTRIBUTING.md).
 maintainer-controlled hosting (Releases/CDN). Never link a contributor's URL
 from `personas.ts` — external content can change after review; the recorded
 SHA-256 binds the acceptance to the exact bytes that were reviewed.
+
+## The manifest + how users get assets
+
+Accepted packs are recorded in the repo-root **`avatars.manifest.json`** —
+persona, files, SHA-256 per file, release URL, and the contributor credit.
+Git history is the tamper-evident acceptance ledger (Release assets alone are
+maintainer-mutable; the in-repo hash is what makes tampering detectable).
+
+Self-hosters fetch assets with one command:
+
+```bash
+pnpm deepinterview avatars pull   # downloads + SHA-256-verifies into apps/web/public/avatars/
+```
+
+After a pull the app serves avatars locally with **zero runtime dependency on
+project infrastructure**; before one, it renders the gradient stage. Assets
+are always optional (the mock-first rule applies to pixels too).
 
 ## Reference implementation
 


### PR DESCRIPTION
Completes the avatar pipeline end to end with the model-weights pattern (manifest in repo, binaries in Releases, one fetch command):

- **`avatars.manifest.json`** — in-repo hash ledger binding acceptance to exact bytes (upgrades the PR-text hashes from #63 into an enforced, verifiable invariant)
- **`deepinterview avatars pull`** — one-command asset fetch with SHA-256 verification into the gitignored `public/avatars/`; offline-capable after fetch
- **`deepinterview avatars verify`** — contributor pre-flight (type/magic/size + prints hashes for the PR); found-by-dogfooding: rejects non-contract file types
- docs/AVATARS.md submission + acceptance flow updated; 20 CLI tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)