### PR TITLE
feat: run every model locally — Ollama + Whisper + Kokoro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,19 +40,48 @@ R2_PUBLIC_URL=
 # ── STT (speech-to-text) ───────────────────────────────────
 # Default = Deepgram nova-3 (the tested path); set DEEPGRAM_API_KEY.
 # Soniox is a BYO alternative — set STT_PROVIDER=soniox + SONIOX_API_KEY.
+# whisper = a local OpenAI-compatible server (see "Local models" below).
 STT_PROVIDER=deepgram
 DEEPGRAM_API_KEY=
 SONIOX_API_KEY=
 
 # ── TTS (text-to-speech) ───────────────────────────────────
+# kokoro = local (see "Local models" below).
 TTS_PROVIDER=cartesia
 CARTESIA_API_KEY=
 ELEVENLABS_API_KEY=
 
 # ── LLM (live + prep/post) ─────────────────────────────────
+# ollama = local (see "Local models" below).
 LLM_PROVIDER=gemini
 GEMINI_API_KEY=
 OPENAI_API_KEY=
+
+# ── Local models (no cloud model keys) ─────────────────────
+# Set LLM_PROVIDER=ollama, STT_PROVIDER=whisper and TTS_PROVIDER=kokoro to run
+# every model on your own machine. All three speak the OpenAI HTTP shape, so
+# they need a base URL instead of an API key — any compatible server works
+# (Ollama, vLLM, LM Studio, llama.cpp, Speaches, kokoro-fastapi).
+#
+# NOTE: LiveKit is the real-time TRANSPORT and is still required. Point
+# LIVEKIT_URL at LiveKit Cloud, or run `livekit-server --dev` locally for a
+# fully offline stack. See docs/LOCAL_MODELS.md.
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_MODEL=qwen3:8b
+WHISPER_BASE_URL=http://localhost:8000/v1
+WHISPER_MODEL=Systran/faster-whisper-small
+KOKORO_BASE_URL=http://localhost:8880/v1
+# KOKORO_MODEL must stay "tts-1": it selects the raw-audio transport in the
+# OpenAI plugin. Any other id silently produces NO audio. kokoro-fastapi
+# ignores the model name itself, so this costs nothing.
+KOKORO_MODEL=tts-1
+# Blank = pick the voice from the session language (Kokoro encodes language in
+# the voice-id prefix: af_/am_=EN, jf_=JA, zf_=ZH, ef_=ES, ff_=FR, …).
+KOKORO_VOICE=
+# Local models are slower than cloud ones. These raise the per-call ceilings so
+# prep and scoring don't time out and silently degrade to a generic result.
+LLM_CALL_TIMEOUT_SEC=300
+SCORE_STAGE_TIMEOUT_SEC=300
 
 # ── Web / company research ─────────────────────────────────
 # SEARCH_PROVIDER selects the company-research backend: mock | tavily | exa.

--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,11 @@ OPENAI_API_KEY=
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen3:8b
 WHISPER_BASE_URL=http://localhost:8000/v1
-WHISPER_MODEL=Systran/faster-whisper-small
+# `base` is the CPU-safe default. Bigger Whisper models blow through the
+# 30s per-request ceiling on CPU (especially in a memory-tight Docker VM) and
+# the turn dies with "failed to recognize speech". Use tiny.en on weak
+# hardware; only go to small/medium with a GPU.
+WHISPER_MODEL=Systran/faster-whisper-base
 KOKORO_BASE_URL=http://localhost:8880/v1
 # KOKORO_MODEL must stay "tts-1": it selects the raw-audio transport in the
 # OpenAI plugin. Any other id silently produces NO audio. kokoro-fastapi

--- a/.env.example
+++ b/.env.example
@@ -78,10 +78,13 @@ KOKORO_MODEL=tts-1
 # Blank = pick the voice from the session language (Kokoro encodes language in
 # the voice-id prefix: af_/am_=EN, jf_=JA, zf_=ZH, ef_=ES, ff_=FR, …).
 KOKORO_VOICE=
-# Local models are slower than cloud ones. These raise the per-call ceilings so
-# prep and scoring don't time out and silently degrade to a generic result.
-LLM_CALL_TIMEOUT_SEC=300
-SCORE_STAGE_TIMEOUT_SEC=300
+# Local models are slower than cloud ones, so the local path needs higher
+# per-call ceilings or prep and scoring time out and silently degrade to a
+# generic result. Left COMMENTED so the cloud defaults (90s / 60s) stay in
+# force for everyone else; `deepinterview init` → "100% local models" writes
+# them for you, or uncomment them here if you wire the local path by hand.
+# LLM_CALL_TIMEOUT_SEC=300
+# SCORE_STAGE_TIMEOUT_SEC=300
 
 # ── Web / company research ─────────────────────────────────
 # SEARCH_PROVIDER selects the company-research backend: mock | tavily | exa.

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ OPENAI_API_KEY=
 # NOTE: LiveKit is the real-time TRANSPORT and is still required. Point
 # LIVEKIT_URL at LiveKit Cloud, or run `livekit-server --dev` locally for a
 # fully offline stack. See docs/LOCAL_MODELS.md.
+# Provider values name the CONTRACT, not a vendor, and are case-insensitive:
+#   LLM_PROVIDER: ollama | vllm | llamacpp | lmstudio | local
+#   STT_PROVIDER: whisper | faster-whisper | qwen3-asr | speaches | local
+#   TTS_PROVIDER: kokoro | local
+# Swapping servers means changing a URL and a model name — never code.
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen3:8b
 WHISPER_BASE_URL=http://localhost:8000/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,12 @@ jobs:
         run: uv --directory services/lightrag run pytest
 
       - name: Validate docker compose
-        run: docker compose config -q
+        # Profiled services are skipped unless their profile is named, so the
+        # `local` (model servers) and `live` (voice worker) blocks need their own
+        # pass or a typo in them would ship unvalidated.
+        run: |
+          docker compose config -q
+          docker compose --profile local --profile live config -q
 
   # Actually BUILD the images so Dockerfile breakage (copy paths, --frozen
   # lockfile drift, the worker model-bake step) surfaces in CI, not at deploy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes, newest first. The README's [News](README.md#news) section
 carries the latest handful of entries; everything lands here permanently.
 Tagged releases: [GitHub Releases](https://github.com/ngoanpv/DeepInterview/releases).
 
+## v0.3.0 — 2026-08-02
+
+- **A fully local model path — no LLM, STT or TTS keys.** `LLM_PROVIDER=ollama`,
+  `STT_PROVIDER=whisper` and `TTS_PROVIDER=kokoro` point each stage at an
+  OpenAI-compatible server on your own machine. No new dependency was added:
+  the existing `livekit-plugins-openai` is reused with a `base_url` override, so
+  any compatible server works (Ollama, vLLM, LM Studio, llama.cpp, Speaches,
+  kokoro-fastapi). `deepinterview init` gained a **"100% local models"** mode and
+  `docker compose --profile local` brings up the model servers.
+  Closes #55, #56, #57.
+- **Verified** on an Apple M5 Pro (24 GB): prep produced a real, CV-grounded
+  six-question plan in 121s on `qwen3:8b` with no degraded stages, and a Kokoro →
+  Whisper round trip through the real worker builders returned the spoken
+  sentence verbatim (3.25s of 24 kHz PCM). Provider selection, fallback and
+  voice/language routing are covered by offline unit tests.
+- **Not verified, so not claimed:** turn latency on local models is not
+  benchmarked, a full microphone session in a LiveKit room has not been run, and
+  the local path is maintainer-tested rather than CI-tested (CI has no models). Kokoro has no Vietnamese voice — `vi` sessions fall back to
+  a cloud voice rather than mispronouncing it. Local STT is batch, so live
+  captions arrive per utterance instead of word by word.
+- **LiveKit remains the real-time transport** even on the local path. Use LiveKit
+  Cloud, or `livekit-server --dev` for a fully offline stack. See
+  [docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md).
+- Local models are slower than cloud ones: `LLM_CALL_TIMEOUT_SEC` and
+  `SCORE_STAGE_TIMEOUT_SEC` are the knobs, and selecting a local provider
+  automatically widens the live per-request ceiling from the SDK's 10s default.
+
 ## v0.2.0 — 2026-07-25
 
 - **Gemini 3.6 Flash + LiveKit Agents 1.6.** Prep and scoring run on Gemini 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,17 @@ Tagged releases: [GitHub Releases](https://github.com/ngoanpv/DeepInterview/rele
   Whisper round trip through the real worker builders returned the spoken
   sentence verbatim (3.25s of 24 kHz PCM). Provider selection, fallback and
   voice/language routing are covered by offline unit tests.
+- **The Whisper default is `faster-whisper-base`, deliberately.** The OpenAI
+  plugin hard-codes a 30s per-request timeout that no setting can raise, so an
+  oversized model doesn't degrade — the turn dies with `failed to recognize
+  speech`. `small` needs ~3.4 GB resident and, in a memory-tight Docker VM, took
+  32s on a 3.6s clip; `base` needs ~220 MB, runs at ~0.09x realtime, and was just
+  as accurate on interview speech. Sizes and per-model timings under concurrent
+  LLM load are in [docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md).
 - **Not verified, so not claimed:** turn latency on local models is not
-  benchmarked, a full microphone session in a LiveKit room has not been run, and
-  the local path is maintainer-tested rather than CI-tested (CI has no models). Kokoro has no Vietnamese voice — `vi` sessions fall back to
+  benchmarked, a full microphone session in a LiveKit room has not yet completed
+  end to end, and the local path is maintainer-tested rather than CI-tested (CI
+  has no models). Tuning local turn latency is tracked as follow-up work. Kokoro has no Vietnamese voice — `vi` sessions fall back to
   a cloud voice rather than mispronouncing it. Local STT is batch, so live
   captions arrive per utterance instead of word by word.
 - **LiveKit remains the real-time transport** even on the local path. Use LiveKit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,16 @@ Tagged releases: [GitHub Releases](https://github.com/ngoanpv/DeepInterview/rele
   32s on a 3.6s clip; `base` needs ~220 MB, runs at ~0.09x realtime, and was just
   as accurate on interview speech. Sizes and per-model timings under concurrent
   LLM load are in [docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md).
+- **A real microphone interview runs end to end on local models.** Verified with
+  a live LiveKit session: the agent spoke in Kokoro's voice, the local Whisper
+  server transcribed real speech, and the report rendered `complete` — with no
+  recognition failures and no stage falling back to a cloud provider. One honest
+  note from that run: `qwen3:8b` did not reliably call the `save_answer` tool, so
+  the shutdown-time transcript recovery supplied the answer. That safety net is
+  pre-existing and worked, but small local models lean on it more than the cloud
+  models do.
 - **Not verified, so not claimed:** turn latency on local models is not
-  benchmarked, a full microphone session in a LiveKit room has not yet completed
-  end to end, and the local path is maintainer-tested rather than CI-tested (CI
+  benchmarked, and the local path is maintainer-tested rather than CI-tested (CI
   has no models). Tuning local turn latency is tracked as follow-up work. Kokoro has no Vietnamese voice — `vi` sessions fall back to
   a cloud voice rather than mispronouncing it. Local STT is batch, so live
   captions arrive per utterance instead of word by word.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,5 +11,5 @@ license: Apache-2.0
 repository-code: "https://github.com/ngoanpv/DeepInterview"
 authors:
   - name: "The DeepInterview contributors"
-version: 0.2.0
-date-released: 2026-07-25
+version: 0.3.0
+date-released: 2026-08-02

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Practicing in your head (or in a text chat) isn't how interviews work. DeepInter
 
 | Stage | Choose with | Cloud vendors (pick one) | Fully local | No key set |
 |---|---|---|---|---|
-| **STT** | `STT_PROVIDER` | **Deepgram nova-3** (default) · Soniox | **`whisper`** — any OpenAI-compatible Whisper server | mock adapter |
+| **STT** | `STT_PROVIDER` | **Deepgram nova-3** (default) · Soniox | **`whisper`** · **`qwen3-asr`** — any OpenAI-compatible server | mock adapter |
 | **TTS** | `TTS_PROVIDER` | **Cartesia sonic** (default) · ElevenLabs Flash v2.5 · Gemini TTS | **`kokoro`** — kokoro-fastapi | mock adapter |
 | **LLM** | `LLM_PROVIDER` | **Gemini live tier** (default) · OpenAI | **`ollama`** — e.g. Qwen3 | mock adapter |
 
@@ -124,8 +124,9 @@ pnpm deepinterview init      # choose "100% local models"
 
 Sets `LLM_PROVIDER=ollama`, `STT_PROVIDER=whisper`, `TTS_PROVIDER=kokoro` — every
 model runs on your machine, no LLM/STT/TTS keys, and nothing about your CV leaves
-your box. Verified end to end on Apple Silicon with `qwen3:8b`: a real,
-CV-grounded question plan in ~2 minutes.
+your box. Verified end to end on Apple Silicon with `qwen3:8b`: a CV-grounded
+question plan in ~2 minutes, then a **live voice interview with a real
+microphone** through to a scored report.
 
 Two honest caveats: **LiveKit is still the real-time transport** (use LiveKit
 Cloud, or `livekit-server --dev` for a fully offline stack), and local STT is

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Practicing in your head (or in a text chat) isn't how interviews work. DeepInter
 - **Prepared like a real interviewer** — before the call it reads your CV + the JD, researches the company, and precomputes a personalized question plan with rubrics; the live loop stays fast because the thinking already happened.
 - **Feedback you can act on** — per-competency rubric scores, model answers, and a study coach that targets exactly the gaps the interview exposed (a closed prep ⇄ interview ⇄ feedback loop).
 - **Multilingual by design** — UI in EN+VI, voice interviews in 7 languages including Vietnamese; STT/TTS route by language automatically, and each language is a pluggable pack.
-- **Yours end to end** — Apache 2.0, fully self-hostable, **bring-your-own keys** for every provider (or run 100% offline on mock adapters), and **no sign-in required**: no account, no login, no data leaving your box unless you choose a provider.
+- **Yours end to end** — Apache 2.0, fully self-hostable, **bring-your-own keys** for every provider — or **run every model locally** (Ollama + Whisper + Kokoro, [docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md)) — and **no sign-in required**: no account, no login, no data leaving your box unless you choose a provider.
 
 ## Features
 
@@ -110,29 +110,46 @@ Practicing in your head (or in a text chat) isn't how interviews work. DeepInter
 
 **Every stage is swappable — bring your own vendor.** The live voice loop is **cascaded STT → LLM → TTS** over LiveKit; you pick each vendor with a single env var (`STT_PROVIDER` / `TTS_PROVIDER` / `LLM_PROVIDER`) plus its key. No code changes, no vendor lock-in — providers sit behind a clean adapter interface, and adding a new one is a small PR (see [CONTRIBUTING.md](CONTRIBUTING.md)). With no keys set, every stage falls back to an offline **mock adapter** so the full loop runs in CI and on day-one clones.
 
-| Stage | Choose with | Vendors (pick one) | No key set |
-|---|---|---|---|
-| **STT** | `STT_PROVIDER` | **Deepgram nova-3** (default) · Soniox | mock adapter (faster-whisper planned) |
-| **TTS** | `TTS_PROVIDER` | **Cartesia sonic** (default) · ElevenLabs Flash v2.5 · Gemini TTS | mock adapter (XTTS planned) |
-| **LLM** | `LLM_PROVIDER` | **Gemini live tier** (default) · OpenAI | mock adapter (Qwen3 planned) |
+| Stage | Choose with | Cloud vendors (pick one) | Fully local | No key set |
+|---|---|---|---|---|
+| **STT** | `STT_PROVIDER` | **Deepgram nova-3** (default) · Soniox | **`whisper`** — any OpenAI-compatible Whisper server | mock adapter |
+| **TTS** | `TTS_PROVIDER` | **Cartesia sonic** (default) · ElevenLabs Flash v2.5 · Gemini TTS | **`kokoro`** — kokoro-fastapi | mock adapter |
+| **LLM** | `LLM_PROVIDER` | **Gemini live tier** (default) · OpenAI | **`ollama`** — e.g. Qwen3 | mock adapter |
+
+### Run it 100% local
+
+```bash
+pnpm deepinterview init      # choose "100% local models"
+```
+
+Sets `LLM_PROVIDER=ollama`, `STT_PROVIDER=whisper`, `TTS_PROVIDER=kokoro` — every
+model runs on your machine, no LLM/STT/TTS keys, and nothing about your CV leaves
+your box. Verified end to end on Apple Silicon with `qwen3:8b`: a real,
+CV-grounded question plan in ~2 minutes.
+
+Two honest caveats: **LiveKit is still the real-time transport** (use LiveKit
+Cloud, or `livekit-server --dev` for a fully offline stack), and local STT is
+batch, so captions appear per utterance rather than word by word. Turn latency
+on local models is not benchmarked, and Kokoro has no Vietnamese voice.
+Full setup, hardware notes and troubleshooting: **[docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md)**.
 
 > **Language routing is automatic — not something you configure.** If your chosen TTS doesn't cover the session language (e.g., Vietnamese on Cartesia), the agent reroutes that session to ElevenLabs or Gemini TTS when a key is present. Cartesia covers en, es, zh, fr, de, ja, pt, hi, it, ko, nl, pl, ru, sv, tr; Deepgram nova-3 covers English + many languages (Vietnamese validation in progress).
 
 ## News
 
+> - **[2026.08]** **Run the whole thing on your own machine.** The LLM, speech-to-text and text-to-speech stages now point at local OpenAI-compatible servers — **Ollama**, a local **Whisper** server and **Kokoro** — so an interview needs no model keys at all. Verified end to end on Apple Silicon; pair it with `livekit-server --dev` for a fully offline stack. English voices for now, and turn latency isn't benchmarked. See [docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md).
 > - **[2026.07]** **Now on Gemini 3.6 Flash + LiveKit Agents 1.6.** Prep and scoring run on **Gemini 3.6 Flash**; the live voice stack moved to livekit-agents 1.6 (Gemini 3-ready function calling on the turn path), and live captions now read as one paragraph per speaker instead of per-fragment lines.
 > - **[2026.07]** **The open-source build is fully uncapped — billing removed.** Self-host with your own keys: no plan gates, no interview caps, no billing tables. Payments live only in the hosted edition; the OSS schema got leaner.
 > - **[2026.07]** **Hardening release.** Opt-in shared-secret auth for the agent API and knowledge sidecar, locked-down Supabase row policies, and periodic transcript checkpointing so a killed process loses seconds of your interview, not all of it.
 > - **[2026.07]** **The study coach now grounds answers in *your* session.** Prep ingests your CV, the JD, and company research into the knowledge sidecar keyed by session — coach answers cite your own materials, not generic tips.
 > - **[2026.06]** **Live voice interviews run on real providers.** The full loop — personalized prep (real Gemini CV/JD analysis + company research) → real-time voice interview on LiveKit (Deepgram STT · Gemini · Cartesia/ElevenLabs TTS) → scored report — now runs end to end, with semantic end-of-turn detection and noise-robust, word-gated barge-in.
-> - **[2026.06]** **`docker compose up` verified.** All images build; the base stack (web + agent API + knowledge sidecar) comes up healthy with **zero keys** on mock adapters; `--profile live` adds the voice worker.
-> - **[next]** The hero demo GIF, hosted live demo, and more language packs.
+> - **[next]** A hosted live demo, and more language packs.
 
 _(Honest by policy — no shipped-feature claims until they're true. Older entries roll into [CHANGELOG.md](CHANGELOG.md).)_
 
 ## Releases
 
-Current release: **[v0.2.0](https://github.com/ngoanpv/DeepInterview/releases/tag/v0.2.0)** (2026-07-25) — the full prep → live voice interview → scoring → coach loop verified on real providers, uncapped billing-free OSS build, hardened API surface, and the community playbook library wired into the question planner. See [Releases](https://github.com/ngoanpv/DeepInterview/releases) for notes; citation metadata lives in [`CITATION.cff`](CITATION.cff).
+Current release: **[v0.3.0](https://github.com/ngoanpv/DeepInterview/releases/tag/v0.3.0)** (2026-08-02) — a fully local model path (Ollama + Whisper + Kokoro) so an interview needs no model keys at all, on top of the v0.2.0 loop: prep → live voice interview → scoring → coach verified on real providers, uncapped billing-free OSS build, hardened API surface, and the community playbook library wired into the question planner. See [Releases](https://github.com/ngoanpv/DeepInterview/releases) for notes; citation metadata lives in [`CITATION.cff`](CITATION.cff).
 
 ## Architecture
 
@@ -182,6 +199,18 @@ Full request-flow diagrams and the multi-agent design live in [`docs/ARCHITECTUR
 - **[The playbook library](skills/README.md)** — browsable interview question-bank packs that directly shape the AI's questions; contributions welcome ([#38](https://github.com/ngoanpv/DeepInterview/issues/38)).
 
 Built in the open, with [Claude Code](https://claude.com/claude-code) as a heavily-used co-author — the AI interviewer declined to interview it. We respond to issues — ghosting contributors is the #1 cause of OSS death, and we don't intend to.
+
+**Standing on other people's shoulders.** The local path is built on
+[LiveKit Agents](https://github.com/livekit/agents),
+[Ollama](https://github.com/ollama/ollama),
+[Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) and
+[faster-whisper](https://github.com/SYSTRAN/faster-whisper). If you want a pure
+local *voice pipeline* rather than a full interview platform, go look at
+[**@huggingface**'s `speech-to-speech`](https://github.com/huggingface/speech-to-speech)
+(Apache-2.0) — the same cascaded VAD → STT → LLM → TTS philosophy we use, with
+MLX on Apple Silicon and an OpenAI Realtime-compatible API. It's the closest
+sibling to this project's local mode and the best place to start if you're
+assembling your own.
 
 ## Contributing
 

--- a/apps/agent/pyproject.toml
+++ b/apps/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepinterview-agent"
-version = "0.2.0"
+version = "0.3.0"
 description = "DeepInterview live voice interviewer + prep/post pipelines (WP-0 shell)."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/apps/agent/src/deepinterview_agent/core/adapters/llm.py
+++ b/apps/agent/src/deepinterview_agent/core/adapters/llm.py
@@ -57,6 +57,15 @@ def _loads_json(text: str) -> Any:
     import re
 
     t = (text or "").strip()
+    # Strip reasoning blocks BEFORE looking for JSON. Local reasoning models
+    # (Qwen3 via Ollama) routinely return "<think>…</think>" inline in content,
+    # and the tolerant scan below takes the FIRST '{' it sees — so a brace
+    # anywhere in the model's scratchpad would be decoded instead of the answer.
+    # Cloud models don't emit these tags, so this is a no-op for them.
+    t = re.sub(r"<(think|thinking)>.*?</\1>", "", t, flags=re.DOTALL | re.IGNORECASE).strip()
+    # An unterminated block means the reply was cut off mid-thought; everything
+    # after the opening tag is scratchpad, never the answer.
+    t = re.sub(r"<(think|thinking)>.*\Z", "", t, flags=re.DOTALL | re.IGNORECASE).strip()
     # Strip a wrapping ```json ... ``` / ``` ... ``` markdown fence, if present.
     if t.startswith("```"):
         t = re.sub(r"^```[^\n]*\n?", "", t)
@@ -134,19 +143,26 @@ class GeminiLLM:
 
 
 class OpenAILLM:
-    """OpenAI via the ``openai`` SDK (lazy import)."""
+    """OpenAI — and any OpenAI-compatible server — via the ``openai`` SDK.
+
+    ``base_url`` is what makes the local path possible: pointed at Ollama's
+    ``/v1`` it drives the whole prep/post pipeline with no cloud key. See
+    :class:`OllamaLLM`.
+    """
 
     def __init__(
         self,
         api_key: str,
         model: str,
         timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
+        base_url: str | None = None,
     ) -> None:
         # No default model — see GeminiLLM.__init__; Settings.openai_model is
         # the single source of truth.
         self._api_key = api_key
         self._model = model
         self._timeout = timeout_sec
+        self._base_url = base_url
 
     def _client(self) -> Any:
         try:
@@ -155,7 +171,7 @@ class OpenAILLM:
             raise RuntimeError(
                 "openai is not installed; install the 'openai' extra."
             ) from exc
-        return AsyncOpenAI(api_key=self._api_key)
+        return AsyncOpenAI(api_key=self._api_key, base_url=self._base_url)
 
     async def complete_text(self, *, system: str, user: str) -> str:
         client = self._client()
@@ -192,6 +208,38 @@ class OpenAILLM:
         return schema.model_validate(_loads_json(resp.choices[0].message.content or "{}"))
 
 
+class OllamaLLM(OpenAILLM):
+    """A local Ollama server through its OpenAI-compatible ``/v1`` endpoint.
+
+    Ollama needs no credential, so a non-empty placeholder key is passed (the
+    SDK requires *something*). Behaviourally this differs from the cloud path in
+    one way that matters: **it retries once when the response doesn't parse.**
+
+    Why only here. Small local models are markedly worse at emitting strict JSON
+    than Gemini/GPT, and this pipeline's largest schema (``QuestionPlan``) is
+    also its keystone — when it fails, ``prep.nodes.question_planner`` silently
+    swaps in the generic mock plan and the candidate sits through an interview
+    whose questions are titled "mock". That exact failure has shipped before.
+    One cheap retry with a blunter instruction converts most near-misses
+    (a stray preamble, a truncated trailing brace) into a usable plan; the cloud
+    adapters stay single-shot so their latency and cost are unchanged.
+    """
+
+    _RETRY_NUDGE = (
+        "Your previous reply could not be parsed as JSON. Reply with the JSON "
+        "value ONLY — no explanation, no markdown fence, no <think> block."
+    )
+
+    async def complete_json(self, *, system: str, user: str, schema: type) -> Any:
+        try:
+            return await super().complete_json(system=system, user=user, schema=schema)
+        except Exception as exc:  # noqa: BLE001 - any parse/validation miss earns one retry
+            log.warning("OllamaLLM: unparseable JSON (%s); retrying once.", exc)
+            return await super().complete_json(
+                system=f"{system}\n\n{self._RETRY_NUDGE}", user=user, schema=schema
+            )
+
+
 def get_llm(settings: Settings) -> LLMAdapter:
     """Choose an LLM adapter from settings, falling back to the mock."""
     provider = (settings.llm_provider or "mock").lower()
@@ -207,6 +255,19 @@ def get_llm(settings: Settings) -> LLMAdapter:
         if settings.openai_api_key:
             return OpenAILLM(settings.openai_api_key, settings.openai_model, timeout)
         log.warning("llm_provider=openai but openai_api_key is missing; using MockLLM.")
+        return MockLLM()
+    if provider == "ollama":
+        # Local: a base URL takes the place of an API key. Everything else in
+        # the factory contract is unchanged — missing config still degrades to
+        # the mock rather than failing the pipeline.
+        if settings.ollama_base_url:
+            return OllamaLLM(
+                settings.local_api_key,
+                settings.ollama_model,
+                timeout,
+                base_url=settings.ollama_base_url,
+            )
+        log.warning("llm_provider=ollama but ollama_base_url is missing; using MockLLM.")
         return MockLLM()
     log.warning("Unknown llm_provider=%r; using MockLLM.", provider)
     return MockLLM()

--- a/apps/agent/src/deepinterview_agent/core/adapters/llm.py
+++ b/apps/agent/src/deepinterview_agent/core/adapters/llm.py
@@ -256,7 +256,7 @@ def get_llm(settings: Settings) -> LLMAdapter:
             return OpenAILLM(settings.openai_api_key, settings.openai_model, timeout)
         log.warning("llm_provider=openai but openai_api_key is missing; using MockLLM.")
         return MockLLM()
-    if provider == "ollama":
+    if provider in {"ollama", "vllm", "llamacpp", "lmstudio", "local"}:
         # Local: a base URL takes the place of an API key. Everything else in
         # the factory contract is unchanged — missing config still degrades to
         # the mock rather than failing the pipeline.
@@ -267,7 +267,7 @@ def get_llm(settings: Settings) -> LLMAdapter:
                 timeout,
                 base_url=settings.ollama_base_url,
             )
-        log.warning("llm_provider=ollama but ollama_base_url is missing; using MockLLM.")
+        log.warning("llm_provider=%s but ollama_base_url is missing; using MockLLM.", provider)
         return MockLLM()
     log.warning("Unknown llm_provider=%r; using MockLLM.", provider)
     return MockLLM()

--- a/apps/agent/src/deepinterview_agent/core/config.py
+++ b/apps/agent/src/deepinterview_agent/core/config.py
@@ -49,6 +49,48 @@ class Settings(BaseSettings):
     # and covers 32 languages incl. vi. Override via ELEVENLABS_MODEL.
     elevenlabs_model: str = "eleven_flash_v2_5"
 
+    # --- local (self-hosted) model servers ------------------------------------
+    # The "runs 100% local, no cloud model keys" path. All three speak the
+    # OpenAI HTTP shape, so they reuse the already-installed openai SDK +
+    # livekit-plugins-openai with a `base_url` override — no extra dependency.
+    #   ollama  -> LLM   (prep, scoring, and the live turn path)
+    #   whisper -> STT   (any OpenAI-compatible /v1/audio/transcriptions server)
+    #   kokoro  -> TTS   (kokoro-fastapi's /v1/audio/speech)
+    # Select them with LLM_PROVIDER=ollama / STT_PROVIDER=whisper /
+    # TTS_PROVIDER=kokoro; each needs its base URL, never an API key.
+    ollama_base_url: str = "http://localhost:11434/v1"
+    ollama_model: str = "qwen3:8b"
+    whisper_base_url: str = "http://localhost:8000/v1"
+    whisper_model: str = "Systran/faster-whisper-small"
+    kokoro_base_url: str = "http://localhost:8880/v1"
+    # MUST stay in the openai plugin's AUDIO_STREAM_MODELS = {"tts-1","tts-1-hd"}.
+    # Any other id routes synthesis down its SSE branch, which parses "data:"
+    # lines: raw audio matches nothing, the stream drains, and the agent emits
+    # NO AUDIO AND NO EXCEPTION. kokoro-fastapi ignores the model name, so
+    # "tts-1" is purely the switch that selects the audio-bytes path.
+    kokoro_model: str = "tts-1"
+    # Blank = pick the voice from the session language (worker._KOKORO_VOICE),
+    # since Kokoro encodes the language in the voice-id prefix. Set it to pin one.
+    kokoro_voice: str = ""
+    # The plugin hard-codes a 24 kHz decode (openai/tts.py SAMPLE_RATE), which
+    # is also Kokoro-82M's native rate. Raw PCM avoids a decode step; a
+    # mismatched rate here produces chipmunk/slow-motion speech, not an error.
+    kokoro_response_format: str = "pcm"
+    # Non-empty placeholder credential for local servers, which need no auth.
+    # It must not be "": the openai plugin raises ValueError on an
+    # explicitly-passed empty key (stt.py/tts.py "OpenAI API key is required").
+    local_api_key: str = "local"
+    # One-shot reachability probe before a live session starts. A local server
+    # that isn't running is the local path's equivalent of a missing API key,
+    # and without this the candidate joins and *then* the first turn errors.
+    local_probe_timeout_sec: float = 2.0
+    # Per-request ceiling on the LIVE path when a local provider is selected.
+    # The SDK's APIConnectOptions default is 10s, which a cloud model always
+    # beats but a local one — cold, or generating on a shared GPU — does not:
+    # every turn would abort before the first token. Applied only when a local
+    # provider is in play, so the cloud path keeps the SDK default.
+    local_provider_timeout_sec: float = 30.0
+
     # --- provider credentials (all optional) ---------------------------------
     gemini_api_key: str | None = None
     openai_api_key: str | None = None

--- a/apps/agent/src/deepinterview_agent/core/config.py
+++ b/apps/agent/src/deepinterview_agent/core/config.py
@@ -61,7 +61,18 @@ class Settings(BaseSettings):
     ollama_base_url: str = "http://localhost:11434/v1"
     ollama_model: str = "qwen3:8b"
     whisper_base_url: str = "http://localhost:8000/v1"
-    whisper_model: str = "Systran/faster-whisper-small"
+    # `base` (multilingual), NOT `small`. Measured on an M5 Pro with the LLM
+    # generating concurrently — the condition that actually holds mid-interview,
+    # since the next utterance is transcribed while the agent is still replying:
+    #   tiny.en  0.06x realtime idle / 0.13x under load
+    #   base     0.09x                / ~0.7x
+    #   small    0.40x                / 0.77x, ~3.4 GB resident
+    # The plugin hard-codes a 30s read timeout that no setting can raise, so the
+    # headroom has to come from the model. `small` in a memory-constrained
+    # Docker VM blew straight through it and the turn died with
+    # "failed to recognize speech". `base` is ~10x lighter and just as accurate
+    # on interview speech. Use `small`/`medium` only with a GPU.
+    whisper_model: str = "Systran/faster-whisper-base"
     kokoro_base_url: str = "http://localhost:8880/v1"
     # MUST stay in the openai plugin's AUDIO_STREAM_MODELS = {"tts-1","tts-1-hd"}.
     # Any other id routes synthesis down its SSE branch, which parses "data:"

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -208,7 +208,7 @@ def build_stt(settings, language="en", mixed=False, vad=None):
     lang = _stt_lang(language, mixed)
     # Local path: no key, a base URL instead. Checked before the cloud branches
     # so an explicit local selection is never overridden.
-    if settings.stt_provider == "whisper":
+    if _provider(settings, "stt") in _LOCAL_STT:
         return _local_whisper_stt(settings, language, mixed, vad=vad)
     # CONFIRMED in live testing (2026-06-10): nova-3 + language=vi returns NO
     # transcripts on Deepgram's streaming API (English worked end-to-end in the
@@ -216,7 +216,7 @@ def build_stt(settings, language="en", mixed=False, vad=None):
     # languages therefore route to nova-2, which supports them in streaming;
     # nova-3 stays for en/multi where it has the lower WER.
     model = "nova-3" if lang in ("en", "multi") else "nova-2"
-    provider = settings.stt_provider
+    provider = _provider(settings, "stt")
     if provider == "deepgram" and settings.deepgram_api_key:
         return _deepgram_stt(lang, model, api_key=settings.deepgram_api_key)
     if provider == "soniox" and settings.soniox_api_key:
@@ -260,12 +260,33 @@ def _require_live_providers(settings) -> None:
         )
 
 
-# Selected local provider -> (base-URL setting, env var name to name in the error).
+# Accepted values per stage for the local path. These name a *contract* — "an
+# OpenAI-compatible server at a base URL" — not a vendor, so each stage takes
+# aliases: whatever you actually run, the adapter is identical. Whisper and
+# Qwen3-ASR both serve /v1/audio/transcriptions; Ollama, vLLM, LM Studio and
+# llama.cpp all serve /v1/chat/completions; Kokoro serves /v1/audio/speech.
+# `local` works everywhere as the neutral name.
+_LOCAL_LLM = frozenset({"ollama", "vllm", "llamacpp", "lmstudio", "local"})
+_LOCAL_STT = frozenset({"whisper", "faster-whisper", "qwen3-asr", "qwen-asr", "speaches", "local"})
+_LOCAL_TTS = frozenset({"kokoro", "local"})
+
+# Selected local provider -> (base-URL setting, env var named in the error).
 _LOCAL_PROVIDERS = {
-    "llm_provider": {"ollama": ("ollama_base_url", "OLLAMA_BASE_URL")},
-    "stt_provider": {"whisper": ("whisper_base_url", "WHISPER_BASE_URL")},
-    "tts_provider": {"kokoro": ("kokoro_base_url", "KOKORO_BASE_URL")},
+    "llm_provider": (_LOCAL_LLM, "ollama_base_url", "OLLAMA_BASE_URL"),
+    "stt_provider": (_LOCAL_STT, "whisper_base_url", "WHISPER_BASE_URL"),
+    "tts_provider": (_LOCAL_TTS, "kokoro_base_url", "KOKORO_BASE_URL"),
 }
+
+
+def _provider(settings, stage: str) -> str:
+    """Normalized provider value for a stage.
+
+    Case matters more than it looks: the builders compared the raw string while
+    preflight lowercased it, so ``STT_PROVIDER=Whisper`` passed the credential
+    check and then fell through to the *Deepgram* default — a cloud call on the
+    "no cloud keys" path. One normalizer, used by both.
+    """
+    return (getattr(settings, f"{stage}_provider", "") or "").strip().lower()
 
 
 def _unreachable_local_providers(settings) -> list[str]:
@@ -280,11 +301,11 @@ def _unreachable_local_providers(settings) -> list[str]:
     import httpx
 
     problems: list[str] = []
-    for field, providers in _LOCAL_PROVIDERS.items():
-        selected = (getattr(settings, field, "") or "").lower()
-        if selected not in providers:
+    for field, (accepted, url_field, env_name) in _LOCAL_PROVIDERS.items():
+        stage = field.removesuffix("_provider")
+        selected = _provider(settings, stage)
+        if selected not in accepted:
             continue
-        url_field, env_name = providers[selected]
         base = (getattr(settings, url_field, "") or "").rstrip("/")
         if not base:
             problems.append(f"{env_name} ({field.upper()}={selected})")
@@ -299,8 +320,8 @@ def _unreachable_local_providers(settings) -> list[str]:
 
 
 def build_llm(settings):
-    provider = settings.llm_provider
-    if provider == "ollama":
+    provider = _provider(settings, "llm")
+    if provider in _LOCAL_LLM:
         from livekit.plugins import openai
 
         # Local LLM on the turn path via Ollama's OpenAI-compatible endpoint.
@@ -390,14 +411,14 @@ def _local_kokoro_tts(settings, language="en"):
 
 def build_tts(settings, language="en"):
     lang = _TTS_LANG.get(language, "en")
-    provider = settings.tts_provider
+    provider = _provider(settings, "tts")
     needs_non_cartesia = language not in _CARTESIA_LANGS
 
     # Local path first: an explicit local selection must never be silently
     # overridden by the cloud language-routing chain below. Kokoro can't speak
     # every language we support, so an unsupported one falls through to the
     # cloud voices rather than reading the text in the wrong language.
-    if provider == "kokoro":
+    if provider in _LOCAL_TTS:
         if language in _KOKORO_VOICE or settings.kokoro_voice:
             return _local_kokoro_tts(settings, language)
         log.warning(
@@ -520,12 +541,8 @@ def build_conn_options(settings):
     three 30s retries would wedge the session for a minute and a half.
     """
     if not any(
-        (getattr(settings, field, "") or "").lower() in local_values
-        for field, local_values in (
-            ("llm_provider", {"ollama"}),
-            ("stt_provider", {"whisper"}),
-            ("tts_provider", {"kokoro"}),
-        )
+        _provider(settings, stage) in accepted
+        for stage, accepted in (("llm", _LOCAL_LLM), ("stt", _LOCAL_STT), ("tts", _LOCAL_TTS))
     ):
         return None
 

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -168,8 +168,48 @@ def _deepgram_stt(lang: str, model: str, api_key=None):
     return deepgram.STT(**kwargs)
 
 
-def build_stt(settings, language="en", mixed=False):
+def _local_whisper_stt(settings, language: str, mixed: bool, vad=None):
+    """Local Whisper (any OpenAI-compatible ``/v1/audio/transcriptions`` server).
+
+    The openai plugin's STT is a BATCH client: its capabilities are
+    ``streaming=use_realtime``, and ``use_realtime=True`` speaks OpenAI's
+    proprietary Realtime WebSocket, which local Whisper servers don't implement.
+    So it is wrapped in the SDK's ``StreamAdapter``, which uses the (already
+    prewarmed) Silero VAD to cut the mic stream into utterances and calls the
+    batch endpoint per utterance, re-exposing ``streaming=True``.
+
+    The trade-off is real and documented: **no interim results** on this path —
+    captions land per utterance instead of word by word. The semantic
+    end-of-turn model reads final transcripts, so turn-taking still works.
+
+    Code-switching does NOT go through ``_stt_lang`` here. That helper returns
+    the string ``"multi"``, which is a *Deepgram model name*; Whisper rejects it
+    and every transcript comes back empty — the same silent-no-transcripts class
+    of failure as the nova-3+vi bug above. Whisper's own mechanism is
+    ``detect_language``, which blanks the language and lets it auto-detect.
+    """
+    from livekit.agents import stt as agents_stt
+    from livekit.plugins import openai
+
+    return agents_stt.StreamAdapter(
+        stt=openai.STT(
+            model=settings.whisper_model,
+            language=_STT_LANG.get(language, "en"),
+            detect_language=mixed,
+            base_url=settings.whisper_base_url,
+            # Local servers want no auth, but the plugin rejects an empty key.
+            api_key=settings.local_api_key,
+        ),
+        vad=vad or build_vad(),
+    )
+
+
+def build_stt(settings, language="en", mixed=False, vad=None):
     lang = _stt_lang(language, mixed)
+    # Local path: no key, a base URL instead. Checked before the cloud branches
+    # so an explicit local selection is never overridden.
+    if settings.stt_provider == "whisper":
+        return _local_whisper_stt(settings, language, mixed, vad=vad)
     # CONFIRMED in live testing (2026-06-10): nova-3 + language=vi returns NO
     # transcripts on Deepgram's streaming API (English worked end-to-end in the
     # same build) — the exact failure this comment predicted. Non-English
@@ -212,6 +252,7 @@ def _require_live_providers(settings) -> None:
         missing.append("CARTESIA_API_KEY (TTS_PROVIDER=cartesia)")
     elif tts == "elevenlabs" and not settings.elevenlabs_api_key:
         missing.append("ELEVENLABS_API_KEY (TTS_PROVIDER=elevenlabs)")
+    missing.extend(_unreachable_local_providers(settings))
     if missing:
         raise RuntimeError(
             "Live interview cannot start — missing provider credentials: "
@@ -219,8 +260,55 @@ def _require_live_providers(settings) -> None:
         )
 
 
+# Selected local provider -> (base-URL setting, env var name to name in the error).
+_LOCAL_PROVIDERS = {
+    "llm_provider": {"ollama": ("ollama_base_url", "OLLAMA_BASE_URL")},
+    "stt_provider": {"whisper": ("whisper_base_url", "WHISPER_BASE_URL")},
+    "tts_provider": {"kokoro": ("kokoro_base_url", "KOKORO_BASE_URL")},
+}
+
+
+def _unreachable_local_providers(settings) -> list[str]:
+    """Local providers have no credential — an unreachable server is the failure.
+
+    A missing API key is caught above; the local path's equivalent is "the model
+    server isn't running", which otherwise surfaces only once the candidate has
+    joined and the first turn errors. One bounded GET per selected local
+    provider, before the greeting, turns that into a startup error naming the
+    URL and the env var. Never on the turn path.
+    """
+    import httpx
+
+    problems: list[str] = []
+    for field, providers in _LOCAL_PROVIDERS.items():
+        selected = (getattr(settings, field, "") or "").lower()
+        if selected not in providers:
+            continue
+        url_field, env_name = providers[selected]
+        base = (getattr(settings, url_field, "") or "").rstrip("/")
+        if not base:
+            problems.append(f"{env_name} ({field.upper()}={selected})")
+            continue
+        try:
+            httpx.get(f"{base}/models", timeout=settings.local_probe_timeout_sec)
+        except Exception as exc:  # noqa: BLE001 - any failure to reach it is fatal
+            # A 4xx/5xx still proves something is listening; only transport
+            # failures (refused/DNS/timeout) mean "server isn't there".
+            problems.append(f"{env_name}={base} unreachable ({type(exc).__name__}: {exc})")
+    return problems
+
+
 def build_llm(settings):
     provider = settings.llm_provider
+    if provider == "ollama":
+        from livekit.plugins import openai
+
+        # Local LLM on the turn path via Ollama's OpenAI-compatible endpoint.
+        return openai.LLM(
+            model=settings.ollama_model,
+            base_url=settings.ollama_base_url,
+            api_key=settings.local_api_key,
+        )
     if provider == "openai" and settings.openai_api_key:
         from livekit.plugins import openai
 
@@ -242,10 +330,81 @@ def build_llm(settings):
 _CARTESIA_LANGS = {"en", "es", "fr", "de", "ja", "zh", "pt", "hi", "it", "ko", "nl", "pl", "ru", "sv", "tr"}
 
 
+# Kokoro-82M encodes the language in the voice id's prefix, so picking a voice
+# IS picking a language: leaving the English default on a Japanese session would
+# read Japanese text with an American accent. Notably absent: Vietnamese —
+# Kokoro has no vi voice, so vi sessions fall through to the cloud chain.
+_KOKORO_VOICE = {
+    "en": "af_heart",
+    "ja": "jf_alpha",
+    "zh": "zf_xiaobei",
+    "es": "ef_dora",
+    "fr": "ff_siwis",
+    "hi": "hf_alpha",
+    "it": "if_sara",
+    "pt": "pf_dora",
+}
+
+
+def _local_kokoro_tts(settings, language="en"):
+    """Local Kokoro (kokoro-fastapi's OpenAI-compatible ``/v1/audio/speech``).
+
+    Wrapped in the SDK's TTS ``StreamAdapter`` because the openai plugin's TTS
+    declares ``streaming=False``: unwrapped, the agent would synthesize a whole
+    answer before speaking a word. The adapter's sentence tokenizer feeds it one
+    sentence at a time as the LLM streams, so speech starts after the first
+    sentence — the same shape as the streaming cloud voices.
+    """
+    from livekit.agents import tts as agents_tts
+    from livekit.plugins import openai
+    from livekit.plugins.openai.tts import AUDIO_STREAM_MODELS
+
+    # Guard the silent-failure mode: a model id outside AUDIO_STREAM_MODELS
+    # sends synthesis down the plugin's SSE branch, which yields no audio and
+    # raises nothing. Never let that happen quietly.
+    model = settings.kokoro_model
+    if model not in AUDIO_STREAM_MODELS:
+        log.warning(
+            "build_tts: KOKORO_MODEL=%r is outside %s, which would produce SILENT "
+            "audio with no error; using 'tts-1' instead (kokoro-fastapi ignores "
+            "the model name).",
+            model,
+            sorted(AUDIO_STREAM_MODELS),
+        )
+        model = "tts-1"
+
+    # An explicit KOKORO_VOICE always wins; otherwise the voice is derived from
+    # the session language so the accent matches the words.
+    voice = settings.kokoro_voice or _KOKORO_VOICE.get(language, "af_heart")
+
+    return agents_tts.StreamAdapter(
+        tts=openai.TTS(
+            model=model,
+            voice=voice,
+            base_url=settings.kokoro_base_url,
+            api_key=settings.local_api_key,
+            response_format=settings.kokoro_response_format,
+        )
+    )
+
+
 def build_tts(settings, language="en"):
     lang = _TTS_LANG.get(language, "en")
     provider = settings.tts_provider
     needs_non_cartesia = language not in _CARTESIA_LANGS
+
+    # Local path first: an explicit local selection must never be silently
+    # overridden by the cloud language-routing chain below. Kokoro can't speak
+    # every language we support, so an unsupported one falls through to the
+    # cloud voices rather than reading the text in the wrong language.
+    if provider == "kokoro":
+        if language in _KOKORO_VOICE or settings.kokoro_voice:
+            return _local_kokoro_tts(settings, language)
+        log.warning(
+            "build_tts: Kokoro has no voice for %r; falling back to a cloud voice. "
+            "Set KOKORO_VOICE to force a specific one.",
+            language,
+        )
 
     # ElevenLabs Flash v2.5 (~75ms, 32 languages incl. vi) is the low-latency
     # multilingual voice: it wins when explicitly selected, and it's the preferred
@@ -348,6 +507,41 @@ def build_room_options(settings):
         return None
 
 
+def build_conn_options(settings):
+    """Widen the SDK's 10s per-request ceiling when a local model is selected.
+
+    ``APIConnectOptions.timeout`` defaults to 10s — comfortable for a cloud
+    model, but a local one that is cold, swapping, or sharing a GPU regularly
+    needs longer just to emit its first token. At the default, every turn aborts
+    before the model answers and the interview is silently dead.
+
+    Returns ``None`` for the all-cloud path so its behaviour is bit-for-bit
+    unchanged. ``max_retry=1`` because a local endpoint that is down stays down:
+    three 30s retries would wedge the session for a minute and a half.
+    """
+    if not any(
+        (getattr(settings, field, "") or "").lower() in local_values
+        for field, local_values in (
+            ("llm_provider", {"ollama"}),
+            ("stt_provider", {"whisper"}),
+            ("tts_provider", {"kokoro"}),
+        )
+    ):
+        return None
+
+    from livekit.agents import APIConnectOptions
+    from livekit.agents.voice.agent_session import SessionConnectOptions
+
+    opts = APIConnectOptions(timeout=settings.local_provider_timeout_sec, max_retry=1)
+    log.info(
+        "build_conn_options: local provider selected; per-request timeout %.0fs",
+        settings.local_provider_timeout_sec,
+    )
+    return SessionConnectOptions(
+        stt_conn_options=opts, llm_conn_options=opts, tts_conn_options=opts
+    )
+
+
 def build_vad(proc: JobProcess | None = None):
     """Return the Silero VAD, preferring the prewarmed per-process instance."""
     if proc is not None and "vad" in proc.userdata:
@@ -444,12 +638,19 @@ async def entrypoint(ctx: JobContext) -> None:
     # Route STT/TTS by the interview's primary language so a non-English session
     # (e.g. Vietnamese) is both understood and spoken — not just prompted for.
     lang_mode = interview_ctx.plan.language_mode
+    # Built once and shared: the local Whisper STT needs a VAD to segment the
+    # mic stream, and loading Silero twice would waste the prewarm.
+    vad = build_vad(ctx.proc)
+    conn_options = build_conn_options(settings)
     session: AgentSession[InterviewUserdata] = AgentSession(
         userdata=userdata,
-        stt=build_stt(settings, lang_mode.primary, lang_mode.mixed),
+        stt=build_stt(settings, lang_mode.primary, lang_mode.mixed, vad=vad),
         llm=build_llm(settings),
         tts=build_tts(settings, lang_mode.primary),
-        vad=build_vad(ctx.proc),
+        vad=vad,
+        # Only set for local providers; None keeps the SDK defaults (see
+        # build_conn_options), so the cloud path is untouched.
+        **({"conn_options": conn_options} if conn_options else {}),
         # Lean live loop: preemptive generation is on by default in 1.5.x;
         # turn_handling adds the noisy-environment defenses (semantic
         # end-of-turn + word-gated interruptions — see build_turn_handling).

--- a/apps/agent/src/deepinterview_agent/worker_coach.py
+++ b/apps/agent/src/deepinterview_agent/worker_coach.py
@@ -49,6 +49,7 @@ from .live.state import InterviewUserdata, weak_areas_summary
 from .worker import (
     _load_context_via_api,
     _session_id_from_room,
+    build_conn_options,
     build_llm,
     build_room_options,
     build_stt,
@@ -83,16 +84,21 @@ async def entrypoint(ctx: JobContext) -> None:
     # turns were captured at all, with an empty list).
     userdata = InterviewUserdata(ctx=interview_ctx, session_id=session_id)
 
+    # Shared with build_stt: the local Whisper path segments the mic with it.
+    vad = build_vad()
+    conn_options = build_conn_options(settings)
     session: AgentSession[InterviewUserdata] = AgentSession(
         userdata=userdata,
-        stt=build_stt(settings, primary),
+        stt=build_stt(settings, primary, vad=vad),
         llm=build_llm(settings),
         tts=build_tts(settings, primary),
-        vad=build_vad(),
+        vad=vad,
         # Same noisy-environment defenses as the interview worker (semantic
         # end-of-turn + word-gated interruptions); preemptive generation is on
         # by default in 1.5.x.
         turn_handling=build_turn_handling(primary),
+        # Local providers need a longer per-request ceiling; None = SDK default.
+        **({"conn_options": conn_options} if conn_options else {}),
     )
 
     # Capture the real coach conversation (CoachAgent has no tools, so nothing

--- a/apps/agent/tests/test_adapters.py
+++ b/apps/agent/tests/test_adapters.py
@@ -1,7 +1,9 @@
-"""Offline tests for the deterministic mock adapters."""
+"""Offline tests for the deterministic mock adapters + local provider selection."""
 
 import asyncio
+from types import SimpleNamespace
 
+from deepinterview_agent.core.adapters.llm import OllamaLLM, get_llm
 from deepinterview_agent.core.adapters.mock import (
     MockEmbeddings,
     MockLLM,
@@ -72,3 +74,78 @@ def test_mock_embeddings_deterministic_and_dim() -> None:
     assert all(len(v) == MockEmbeddings.DIM for v in a)
     # Different text -> different vector.
     assert a[0] != a[1]
+
+
+# --- local provider selection (the offline half of the "no cloud keys" path) ---
+#
+# These pin the FACTORY, not the servers: constructing an adapter performs no
+# network I/O, so they stay hermetic and run in plain CI (no extras needed).
+# What must not regress is the contract that a misconfigured local provider
+# degrades to the mock instead of raising — and, just as importantly, that a
+# correctly configured one does NOT silently stay on the mock.
+
+
+def _settings(**overrides):
+    """Real Settings with env ignored, so a developer's .env can't sway a test."""
+    base = {
+        "llm_provider": "mock",
+        "ollama_base_url": "http://localhost:11434/v1",
+        "ollama_model": "qwen3:8b",
+        "local_api_key": "local",
+        "llm_call_timeout_sec": 90.0,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_get_llm_ollama_returns_local_adapter() -> None:
+    """LLM_PROVIDER=ollama + a base URL selects the local adapter, not the mock.
+
+    The failure this guards against is silent: a local provider that falls
+    through to MockLLM still "works", and every generated question comes back
+    titled "mock" (see the _loads_json docstring in core/adapters/llm.py).
+    """
+    llm = get_llm(_settings(llm_provider="ollama"))
+    assert isinstance(llm, OllamaLLM)
+    assert llm._base_url == "http://localhost:11434/v1"
+    assert llm._model == "qwen3:8b"
+    # No cloud credential is involved: the key is the non-empty placeholder the
+    # openai SDK requires, never a real one.
+    assert llm._api_key == "local"
+
+
+def test_get_llm_ollama_without_base_url_falls_back_to_mock() -> None:
+    llm = get_llm(_settings(llm_provider="ollama", ollama_base_url=""))
+    assert isinstance(llm, MockLLM)
+
+
+def test_ollama_llm_retries_once_on_unparseable_json() -> None:
+    """A small local model's first reply is often unparseable; one retry saves it.
+
+    Gemini/GPT are single-shot; this retry exists only on the local path, where
+    the keystone QuestionPlan call is the one most likely to come back wrapped
+    in prose or a <think> block.
+    """
+    calls: list[str] = []
+    llm = OllamaLLM("local", "qwen3:8b", 90.0, base_url="http://x/v1")
+
+    async def _fake(_self, *, system: str, user: str, schema: type):
+        calls.append(system)
+        if len(calls) == 1:
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+        return build_mock(schema)
+
+    # Patch the inherited OpenAI implementation the subclass delegates to.
+    import deepinterview_agent.core.adapters.llm as llm_mod
+
+    original = llm_mod.OpenAILLM.complete_json
+    llm_mod.OpenAILLM.complete_json = _fake  # type: ignore[assignment]
+    try:
+        out = _run(llm.complete_json(system="s", user="u", schema=QuestionPlan))
+    finally:
+        llm_mod.OpenAILLM.complete_json = original  # type: ignore[assignment]
+
+    assert isinstance(out, QuestionPlan)
+    assert len(calls) == 2, "expected exactly one retry"
+    assert "could not be parsed as JSON" in calls[1], "retry must add the nudge"
+    assert "could not be parsed as JSON" not in calls[0], "first call stays clean"

--- a/apps/agent/tests/test_llm_json.py
+++ b/apps/agent/tests/test_llm_json.py
@@ -45,3 +45,34 @@ def test_question_plan_survives_trailing_extra_data() -> None:
     payload = plan.model_dump_json() + '\n\n{"note": "duplicate emission"}'
     parsed = QuestionPlan.model_validate(_loads_json(payload))
     assert parsed.model_dump() == plan.model_dump()
+
+
+# --- reasoning-block stripping (the local/Qwen3 path) -------------------------
+
+
+def test_loads_json_strips_think_block() -> None:
+    """A <think> block must be removed BEFORE the first-brace scan.
+
+    Qwen3 via Ollama routinely emits its scratchpad inline in `content`. The
+    tolerant parser below takes the FIRST '{' it finds, so a brace anywhere in
+    that scratchpad would be decoded as the answer — yielding a valid-looking
+    but wrong object, or a parse failure that drops the pipeline to the mock.
+    """
+    raw = '<think>Maybe {"decoy": 1} would work? No.</think>\n{"real": true}'
+    assert _loads_json(raw) == {"real": True}
+
+
+def test_loads_json_strips_unterminated_think_tail() -> None:
+    """A reply cut off mid-thought has no closing tag; the tail is never JSON."""
+    raw = '{"real": true}\n<think>now let me double check {"decoy": 2}'
+    assert _loads_json(raw) == {"real": True}
+
+
+def test_loads_json_think_block_is_case_and_tag_insensitive() -> None:
+    assert _loads_json('<THINKING>{"decoy": 1}</THINKING>{"real": 1}') == {"real": 1}
+
+
+def test_loads_json_leaves_cloud_responses_untouched() -> None:
+    """No <think> tags means byte-identical behaviour for Gemini/OpenAI."""
+    assert _loads_json('{"a": 1}') == {"a": 1}
+    assert _loads_json('```json\n{"a": 1}\n```') == {"a": 1}

--- a/apps/agent/tests/test_worker_livekit.py
+++ b/apps/agent/tests/test_worker_livekit.py
@@ -766,3 +766,34 @@ def test_unreachable_local_providers_names_the_url_and_env_var() -> None:
 
     # All-cloud selection probes nothing.
     assert worker._unreachable_local_providers(_local_settings(llm_provider="gemini")) == []
+
+
+def test_local_provider_values_are_case_insensitive_and_aliased() -> None:
+    """The provider value names a CONTRACT, not a vendor — and case must not matter.
+
+    Two things this pins. First, the builders once compared the raw string while
+    preflight lowercased it, so ``STT_PROVIDER=Whisper`` passed the credential
+    check and then fell through to the DEEPGRAM default — a cloud call on the
+    "no cloud keys" path. Second, any server speaking the OpenAI shape works
+    (Whisper, Qwen3-ASR, vLLM, LM Studio), so each stage accepts aliases and the
+    neutral value ``local``.
+    """
+    from livekit.plugins import openai as lk_openai
+
+    for value in ("whisper", "Whisper", "QWEN3-ASR", "qwen-asr", "local", " speaches "):
+        stt = worker.build_stt(
+            _local_settings(stt_provider=value), "en", vad=SimpleNamespace()
+        )
+        assert isinstance(stt.wrapped_stt, lk_openai.STT), f"{value!r} must stay local"
+        assert str(stt.wrapped_stt._client.base_url).startswith("http://localhost:8000")
+
+    for value in ("ollama", "Ollama", "vllm", "lmstudio", "local"):
+        llm = worker.build_llm(_local_settings(llm_provider=value))
+        assert str(llm._client.base_url).startswith("http://localhost:11434"), value
+
+    for value in ("kokoro", "Kokoro", "local"):
+        tts = worker.build_tts(_local_settings(tts_provider=value), "en")
+        assert tts._wrapped_tts._opts.voice == "af_heart", value
+
+    # And an unknown value must NOT be treated as local.
+    assert worker._unreachable_local_providers(_local_settings(stt_provider="deepgram")) == []

--- a/apps/agent/tests/test_worker_livekit.py
+++ b/apps/agent/tests/test_worker_livekit.py
@@ -589,3 +589,180 @@ def test_shutdown_repo_save_context_failure_marks_error_and_skips_scoring(
     assert ("update_status:error", drive.session_id) in drive.repo.calls
     assert build_deps().repo.get_status(drive.session_id) == "error"
     assert not any(u.endswith("/api/score") for u in drive.http.urls())
+
+
+# --- local providers: the "no cloud model keys" path --------------------------
+#
+# Construction-only, like the Deepgram tests above: none of these plugin
+# __init__s perform network I/O (each only builds an AsyncClient), so the whole
+# block stays offline. Every assertion here pins a failure mode that is SILENT
+# in production — wrong audio branch, wrong language token, a cloud provider
+# quietly substituted for the local one.
+
+
+def _local_settings(**overrides):
+    base = {
+        "llm_provider": "mock",
+        "stt_provider": "mock",
+        "tts_provider": "mock",
+        "ollama_base_url": "http://localhost:11434/v1",
+        "ollama_model": "qwen3:8b",
+        "whisper_base_url": "http://localhost:8000/v1",
+        "whisper_model": "Systran/faster-whisper-small",
+        "kokoro_base_url": "http://localhost:8880/v1",
+        "kokoro_model": "tts-1",
+        "kokoro_voice": "",
+        "kokoro_response_format": "pcm",
+        "local_api_key": "local",
+        "local_provider_timeout_sec": 30.0,
+        "gemini_api_key": None,
+        "elevenlabs_api_key": None,
+        "elevenlabs_model": "eleven_flash_v2_5",
+        "cartesia_api_key": None,
+        "gemini_tts_model": "gemini-2.5-flash-preview-tts",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_build_llm_ollama_points_at_local_server() -> None:
+    """LLM_PROVIDER=ollama must build a local client, never the keyless default.
+
+    worker.build_llm's last resort is ``openai.LLM()`` — which talks to
+    api.openai.com. If the ollama branch is ever removed or reordered, the
+    "runs locally" path silently becomes a cloud call.
+    """
+    pytest.importorskip("livekit.plugins.openai")
+    llm = worker.build_llm(_local_settings(llm_provider="ollama"))
+    assert str(llm._client.base_url).startswith("http://localhost:11434")
+    assert llm._opts.model == "qwen3:8b"
+
+
+def test_build_stt_whisper_wraps_in_stream_adapter() -> None:
+    """openai.STT is a BATCH client; unwrapped it cannot drive a live session.
+
+    Its capabilities are streaming=use_realtime (False here), so it must be
+    wrapped in the SDK's StreamAdapter, which VAD-segments the mic and re-exposes
+    streaming=True. Without the wrapper AgentSession has no streaming STT.
+    """
+    pytest.importorskip("livekit.plugins.openai")
+    from livekit.plugins import openai as lk_openai
+
+    stt = worker.build_stt(_local_settings(stt_provider="whisper"), "en", vad=SimpleNamespace())
+    assert stt.capabilities.streaming is True
+    assert isinstance(stt.wrapped_stt, lk_openai.STT)
+    assert stt.wrapped_stt.capabilities.streaming is False
+    assert str(stt.wrapped_stt._client.base_url).startswith("http://localhost:8000")
+
+
+def test_build_stt_whisper_code_switching_uses_detect_language() -> None:
+    """mixed=True must NOT send "multi" — that is a Deepgram model name.
+
+    _stt_lang returns "multi" for code-switching sessions. Whisper rejects it and
+    returns NO transcripts at all — the same silent failure class as the
+    nova-3+vi bug. Whisper's own mechanism is detect_language.
+    """
+    pytest.importorskip("livekit.plugins.openai")
+    stt = worker.build_stt(
+        _local_settings(stt_provider="whisper"), "vi", mixed=True, vad=SimpleNamespace()
+    )
+    assert stt.wrapped_stt._opts.detect_language is True
+    assert str(stt.wrapped_stt._opts.language) != "multi"
+
+
+def test_build_tts_kokoro_uses_the_audio_branch_not_sse() -> None:
+    """The model id decides the transport, and the wrong one is SILENT.
+
+    openai.TTS routes to AudioChunkedStream only for models in
+    AUDIO_STREAM_MODELS; anything else goes to SSEChunkedStream, which parses
+    "data:" lines. Kokoro returns raw audio, so that branch emits no frames and
+    raises nothing — the agent simply never speaks.
+    """
+    pytest.importorskip("livekit.plugins.openai")
+    from livekit.plugins.openai.tts import AUDIO_STREAM_MODELS
+
+    tts = worker.build_tts(_local_settings(tts_provider="kokoro"), "en")
+    assert tts._wrapped_tts._opts.model in AUDIO_STREAM_MODELS
+    assert tts._wrapped_tts._opts.response_format == "pcm"
+    # Wrapped for sentence-at-a-time synthesis: openai.TTS is non-streaming, so
+    # unwrapped the agent would buffer a whole answer before speaking.
+    assert tts.capabilities.streaming is True
+
+
+def test_build_tts_kokoro_coerces_a_model_that_would_be_silent() -> None:
+    tts = worker.build_tts(_local_settings(tts_provider="kokoro", kokoro_model="kokoro"), "en")
+    assert tts._wrapped_tts._opts.model == "tts-1"
+
+
+def test_build_tts_kokoro_picks_the_voice_from_the_language() -> None:
+    """Kokoro encodes language in the voice-id prefix, so voice IS language."""
+    en = worker.build_tts(_local_settings(tts_provider="kokoro"), "en")
+    ja = worker.build_tts(_local_settings(tts_provider="kokoro"), "ja")
+    assert en._wrapped_tts._opts.voice == "af_heart"
+    assert ja._wrapped_tts._opts.voice == "jf_alpha"
+    # An explicit KOKORO_VOICE always wins.
+    pinned = worker.build_tts(
+        _local_settings(tts_provider="kokoro", kokoro_voice="bf_emma"), "en"
+    )
+    assert pinned._wrapped_tts._opts.voice == "bf_emma"
+
+
+def test_build_tts_kokoro_beats_the_cloud_language_reroute() -> None:
+    """An explicit local selection must never be upgraded to a paid vendor.
+
+    build_tts reroutes languages Cartesia can't speak to ElevenLabs/Gemini. A
+    stray ELEVENLABS_API_KEY in .env must not turn the "100% local" path into a
+    cloud call for a language Kokoro DOES speak.
+    """
+    tts = worker.build_tts(
+        _local_settings(tts_provider="kokoro", elevenlabs_api_key="x"), "ja"
+    )
+    assert tts._wrapped_tts._opts.voice == "jf_alpha"
+
+
+def test_build_tts_kokoro_falls_back_for_a_language_it_cannot_speak() -> None:
+    """Kokoro has no Vietnamese voice; speaking vi with an English one is worse
+    than honestly falling through to the cloud chain."""
+    pytest.importorskip("livekit.plugins.elevenlabs")
+    from livekit.plugins import elevenlabs
+
+    tts = worker.build_tts(_local_settings(tts_provider="kokoro", elevenlabs_api_key="x"), "vi")
+    assert isinstance(tts, elevenlabs.TTS), "vi must reroute to a voice that speaks it"
+
+
+def test_build_conn_options_only_widens_for_local_providers() -> None:
+    """The SDK's 10s per-request ceiling kills local turns before the first token.
+
+    Cloud path must keep the SDK default (None), or this change would silently
+    alter production timeout behaviour for every existing deployment.
+    """
+    assert worker.build_conn_options(_local_settings()) is None
+    assert worker.build_conn_options(_local_settings(llm_provider="gemini")) is None
+
+    opts = worker.build_conn_options(_local_settings(llm_provider="ollama"))
+    assert opts is not None
+    assert opts.llm_conn_options.timeout == 30.0
+    assert opts.stt_conn_options.timeout == 30.0
+    # A local endpoint that is down stays down: don't wedge the turn on retries.
+    assert opts.llm_conn_options.max_retry == 1
+
+
+def test_unreachable_local_providers_names_the_url_and_env_var() -> None:
+    """A local server that isn't running is the local path's missing API key.
+
+    Without this the candidate joins and only THEN does the first turn fail.
+    """
+    settings = _local_settings(llm_provider="ollama", ollama_base_url="http://127.0.0.1:1/v1")
+    problems = worker._unreachable_local_providers(settings)
+    assert len(problems) == 1
+    assert "OLLAMA_BASE_URL" in problems[0]
+    assert "http://127.0.0.1:1/v1" in problems[0]
+
+    # Blank URL is reported as missing config, not as a connection failure.
+    blank = worker._unreachable_local_providers(
+        _local_settings(tts_provider="kokoro", kokoro_base_url="")
+    )
+    assert blank == ["KOKORO_BASE_URL (TTS_PROVIDER=kokoro)"]
+
+    # All-cloud selection probes nothing.
+    assert worker._unreachable_local_providers(_local_settings(llm_provider="gemini")) == []

--- a/apps/agent/uv.lock
+++ b/apps/agent/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "deepinterview-agent"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -89,6 +89,7 @@ async function collectLlm(existing: Values, values: Values): Promise<void> {
       options: [
         { value: "gemini", label: "Google Gemini", hint: "default" },
         { value: "openai", label: "OpenAI" },
+        { value: "ollama", label: "Ollama (local)", hint: "no key" },
         { value: "mock", label: "Mock — offline, no key" },
       ],
     }),
@@ -103,6 +104,18 @@ async function collectLlm(existing: Values, values: Values): Promise<void> {
     values.OPENAI_API_KEY = await secret(
       "OpenAI API key",
       existing.OPENAI_API_KEY,
+    );
+  } else if (provider === "ollama") {
+    // Local servers authenticate with nothing — a base URL replaces the key.
+    values.OLLAMA_BASE_URL = await field(
+      "Ollama base URL",
+      existing.OLLAMA_BASE_URL,
+      "http://localhost:11434/v1",
+    );
+    values.OLLAMA_MODEL = await field(
+      "Ollama model",
+      existing.OLLAMA_MODEL || "qwen3:8b",
+      "qwen3:8b",
     );
   }
 }
@@ -119,10 +132,19 @@ async function collectStt(existing: Values, values: Values): Promise<void> {
           hint: "nova-3, the tested path",
         },
         { value: "soniox", label: "Soniox" },
+        { value: "whisper", label: "Whisper (local)", hint: "no key" },
       ],
     }),
   );
   values.STT_PROVIDER = provider;
+  if (provider === "whisper") {
+    values.WHISPER_BASE_URL = await field(
+      "Whisper server base URL (OpenAI-compatible)",
+      existing.WHISPER_BASE_URL,
+      "http://localhost:8000/v1",
+    );
+    return;
+  }
   const key = provider === "deepgram" ? "DEEPGRAM_API_KEY" : "SONIOX_API_KEY";
   values[key] = await secret(`${provider} API key`, existing[key]);
 }
@@ -135,10 +157,22 @@ async function collectTts(existing: Values, values: Values): Promise<void> {
       options: [
         { value: "cartesia", label: "Cartesia", hint: "default" },
         { value: "elevenlabs", label: "ElevenLabs" },
+        { value: "kokoro", label: "Kokoro (local)", hint: "no key" },
       ],
     }),
   );
   values.TTS_PROVIDER = provider;
+  if (provider === "kokoro") {
+    values.KOKORO_BASE_URL = await field(
+      "Kokoro base URL (OpenAI-compatible)",
+      existing.KOKORO_BASE_URL,
+      "http://localhost:8880/v1",
+    );
+    // Pinned, not asked: this id selects the raw-audio transport in the
+    // OpenAI plugin. Any other value silently yields no audio at all.
+    values.KOKORO_MODEL = "tts-1";
+    return;
+  }
   const key =
     provider === "cartesia" ? "CARTESIA_API_KEY" : "ELEVENLABS_API_KEY";
   values[key] = await secret(`${provider} API key`, existing[key]);
@@ -230,6 +264,11 @@ async function runWizard(existing: Values): Promise<Values> {
           hint: "real AI, no microphone",
         },
         {
+          value: "local",
+          label: "100% local models",
+          hint: "Ollama + Whisper + Kokoro — no model keys",
+        },
+        {
           value: "offline",
           label: "Offline demo",
           hint: "zero keys — mock providers",
@@ -237,6 +276,51 @@ async function runWizard(existing: Values): Promise<Values> {
       ],
     }),
   );
+
+  if (mode === "local") {
+    values.LLM_PROVIDER = "ollama";
+    values.STT_PROVIDER = "whisper";
+    values.TTS_PROVIDER = "kokoro";
+    // Company research is the one remaining outbound call; keep it offline so
+    // "no data leaves your machine" is actually true in this mode.
+    values.SEARCH_PROVIDER = "mock";
+    values.EMBEDDINGS_PROVIDER = "mock";
+    // Local models are slower; the cloud defaults (90s/60s) time out and
+    // silently degrade prep and scoring to generic results.
+    values.LLM_CALL_TIMEOUT_SEC = "300";
+    values.SCORE_STAGE_TIMEOUT_SEC = "300";
+    values.OLLAMA_BASE_URL = await field(
+      "Ollama base URL",
+      existing.OLLAMA_BASE_URL,
+      "http://localhost:11434/v1",
+    );
+    values.OLLAMA_MODEL = await field(
+      "Ollama model",
+      existing.OLLAMA_MODEL || "qwen3:8b",
+      "qwen3:8b",
+    );
+    values.WHISPER_BASE_URL = await field(
+      "Whisper server base URL (OpenAI-compatible)",
+      existing.WHISPER_BASE_URL,
+      "http://localhost:8000/v1",
+    );
+    values.KOKORO_BASE_URL = await field(
+      "Kokoro base URL (OpenAI-compatible)",
+      existing.KOKORO_BASE_URL,
+      "http://localhost:8880/v1",
+    );
+    values.KOKORO_MODEL = "tts-1";
+    note(
+      "Every model runs on your machine — no LLM, STT or TTS keys.\n" +
+        "LiveKit is still the real-time transport: use LiveKit Cloud, or run\n" +
+        "`livekit-server --dev` locally for a fully offline stack.\n" +
+        "See docs/LOCAL_MODELS.md for the model-server setup.",
+      "100% local models",
+    );
+    await collectLiveKit(existing, values);
+    await collectSupabase(existing, values);
+    return values;
+  }
 
   if (mode === "offline") {
     values.LLM_PROVIDER = "mock";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,67 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ── Local model servers (the "no cloud model keys" path) ───────────────────
+  # Gated behind the `local` profile, exactly like the voice worker above, so
+  # the base stack never pulls these multi-GB images:
+  #   docker compose --profile local --profile live up
+  # Then select them:  LLM_PROVIDER=ollama STT_PROVIDER=whisper TTS_PROVIDER=kokoro
+  #
+  # NOTE for macOS: Docker Desktop has no GPU passthrough, so an Ollama running
+  # in this container is CPU-only and far too slow for a live voice loop. On a
+  # Mac, run Ollama natively (it uses Metal) and point the agent at it with
+  # OLLAMA_BASE_URL=http://host.docker.internal:11434/v1 instead of using this
+  # service. That is exactly why these are base URLs and not hard-coded hosts.
+  ollama:
+    image: ollama/ollama:latest
+    profiles:
+      - local
+    ports:
+      - "127.0.0.1:11434:11434"
+    environment:
+      # The truncation fix: Ollama's default context window cannot hold a CV +
+      # JD + the JSON schema, and it truncates SILENTLY — producing a well-formed
+      # plan about a candidate the model never actually read.
+      - OLLAMA_CONTEXT_LENGTH=16384
+    volumes:
+      - ollama-models:/root/.ollama
+    restart: unless-stopped
+
+  # One-shot: pulls the model so the first interview doesn't 404. Exits when done.
+  ollama-pull:
+    image: ollama/ollama:latest
+    profiles:
+      - local
+    depends_on:
+      - ollama
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    entrypoint:
+      - /bin/sh
+      - -c
+      - ollama pull ${OLLAMA_MODEL:-qwen3:8b}
+    restart: "no"
+
+  # STT: any OpenAI-compatible /v1/audio/transcriptions server.
+  whisper:
+    image: ghcr.io/speaches-ai/speaches:latest-cpu
+    profiles:
+      - local
+    ports:
+      - "127.0.0.1:8001:8000"
+    volumes:
+      - whisper-models:/home/ubuntu/.cache/huggingface
+    restart: unless-stopped
+
+  # TTS: kokoro-fastapi speaks the OpenAI /v1/audio/speech shape.
+  kokoro:
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+    profiles:
+      - local
+    ports:
+      - "127.0.0.1:8880:8880"
+    restart: unless-stopped
+
   web:
     build:
       context: .
@@ -153,3 +214,9 @@ services:
       retries: 5
       start_period: 20s
     restart: unless-stopped
+
+volumes:
+  # Model weights for the `local` profile — multi-GB, so they persist across
+  # `docker compose down` and are never re-downloaded.
+  ollama-models:
+  whisper-models:

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -180,10 +180,22 @@ On an Apple M5 Pro (24 GB), Ollama 0.32.5 + `qwen3:8b`, Speaches
 - Provider selection, fallback, and the language/voice routing are covered by
   unit tests that run with no models installed.
 
-**Not verified, and therefore not claimed:** turn latency, barge-in feel, and a
-full microphone-in-a-LiveKit-room session — that last one needs a human to speak,
-so it is not something CI or a scripted check can stand in for. Non-English local
-voice is untested, as is any hardware other than the above.
+- **A live microphone interview, end to end.** A real LiveKit session with a
+  human speaking: the agent spoke in Kokoro's voice, the local Whisper server
+  returned real transcripts, and the report rendered `complete` — with zero
+  recognition failures and zero stages falling back to a cloud provider.
+
+**One thing to expect with small local models.** In that run `qwen3:8b` did not
+reliably call the `save_answer` tool mid-interview, so the worker's shutdown-time
+transcript recovery supplied the answer instead. The report was still correct —
+that safety net is pre-existing and is exactly what it's for — but a local model
+leans on it more than Gemini or GPT do. If your report looks thin, check the
+worker log for `recovered N answer(s) from transcript`; a larger model calls the
+tool more consistently.
+
+**Not verified, and therefore not claimed:** turn latency and barge-in feel are
+not benchmarked. Non-English local voice is untested, as is any hardware other
+than the above.
 
 ## 5. When it goes wrong
 
@@ -216,3 +228,46 @@ stage. DeepInterview needs to own the LLM turn itself (the interviewer calls
 a black-box pipeline that answers for us can't slot into the cascade. If it ever
 grows a transcription-only session mode, it would drop straight into
 `STT_PROVIDER`.
+
+---
+
+## Compatibility: the adapter follows a contract, not a vendor
+
+Each stage talks to **one OpenAI-format endpoint over a base URL**. Anything that
+speaks that shape works — swapping the server means changing a URL and a model
+name, never code. The provider value is case-insensitive and takes aliases, so
+you can name what you actually run (or just say `local`).
+
+| Stage | Endpoint the adapter calls | Accepted `*_PROVIDER` values | Known-working servers |
+|---|---|---|---|
+| **LLM** | `POST /v1/chat/completions` | `ollama` · `vllm` · `llamacpp` · `lmstudio` · `local` | Ollama *(verified)*, vLLM, LM Studio, llama.cpp, LocalAI |
+| **STT** | `POST /v1/audio/transcriptions` | `whisper` · `faster-whisper` · `qwen3-asr` · `qwen-asr` · `speaches` · `local` | Speaches / faster-whisper *(verified)*, **Qwen3-ASR**, whisper.cpp server, vLLM |
+| **TTS** | `POST /v1/audio/speech` | `kokoro` · `local` | kokoro-fastapi *(verified)* |
+
+*(verified)* means it was run end to end for the v0.3.0 release; the others
+implement the same endpoint but haven't been exercised here.
+
+### Qwen3-ASR instead of Whisper
+
+[Qwen3-ASR](https://github.com/QwenLM/Qwen3-ASR) (Alibaba, 52 languages) is a
+strong alternative — particularly for non-English sessions, where Whisper's
+smaller checkpoints weaken. Community servers wrap it behind the same
+OpenAI-compatible `/v1/audio/transcriptions` route, and vLLM supports it
+natively, so it drops in with no code change:
+
+```bash
+STT_PROVIDER=qwen3-asr
+WHISPER_BASE_URL=http://localhost:8001/v1     # wherever you serve it
+WHISPER_MODEL=Qwen/Qwen3-ASR-1.7B
+```
+
+The same 30-second-per-request ceiling applies, so check your throughput on your
+own hardware before committing to it for live interviews.
+
+### Adding a stage your server does differently
+
+If a server deviates from the OpenAI shape, the change is contained to one
+builder in `apps/agent/src/deepinterview_agent/worker.py`
+(`_local_whisper_stt`, `_local_kokoro_tts`, `build_llm`) plus `get_llm` in
+`core/adapters/llm.py` for the prep/scoring path. Everything else — provider
+selection, preflight, timeouts, language routing — is already stage-generic.

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -1,0 +1,197 @@
+# Run DeepInterview on local models
+
+Every AI stage — the LLM, speech-to-text and text-to-speech — can run on your own
+machine. No OpenAI key, no Gemini key, no Deepgram key, no Cartesia key, and
+nothing about your CV leaves your box.
+
+```bash
+LLM_PROVIDER=ollama   STT_PROVIDER=whisper   TTS_PROVIDER=kokoro
+```
+
+All three are reached over the **OpenAI HTTP shape**, so they take a base URL
+instead of an API key, and any compatible server works — Ollama, vLLM, LM Studio,
+llama.cpp, Speaches, kokoro-fastapi. DeepInterview added no new dependency for
+this: it reuses `livekit-plugins-openai` with a `base_url` override.
+
+> ### One honest caveat, up front
+> **LiveKit is still the real-time transport.** Local models replace the *AI*
+> vendors, not the WebRTC layer. You have two options:
+> - point `LIVEKIT_URL` at LiveKit Cloud (free tier is enough for self-hosting), or
+> - run `livekit-server --dev` locally for a genuinely offline stack.
+>
+> So the accurate claim is **"no cloud model keys / no per-minute AI vendor
+> costs"** — not "no cloud at all". Everything else on this page is local.
+
+---
+
+## 1. Start the model servers
+
+### LLM — Ollama
+
+Run Ollama **natively**, not in Docker, on macOS and Windows: Docker Desktop has
+no GPU passthrough, so a containerised Ollama is CPU-only and far too slow for a
+live conversation. Native Ollama uses Metal on Apple Silicon.
+
+```bash
+# macOS / Linux
+curl -fsSL https://ollama.com/install.sh | sh   # or: brew install ollama
+
+# The context length is NOT optional — see "Why 16k" below.
+OLLAMA_CONTEXT_LENGTH=16384 ollama serve
+
+ollama pull qwen3:8b        # ~5 GB on disk
+```
+
+**Why 16k.** The question planner's prompt is your CV + the job description +
+company research + the JSON schema it must fill. Ollama's default context window
+is smaller than that, and it truncates **silently** — you get a well-formed
+interview plan about a candidate the model never actually read. This is the
+single most likely way to get a disappointing local run.
+
+**Model choice.** `qwen3:8b` is the smallest model verified to produce a real,
+grounded question plan (see "What we verified" below). Smaller models tend to
+fail the JSON contract, which lands you on the generic fallback plan. If you have
+the memory, `qwen3:14b` has more headroom.
+
+### STT — a local Whisper server
+
+Any server exposing `POST /v1/audio/transcriptions`:
+
+```bash
+docker run -d -p 8001:8000 ghcr.io/speaches-ai/speaches:latest-cpu
+
+# Speaches ships no weights — download the model once, or every transcription
+# 404s with "Model ... is not installed locally".
+curl -X POST http://localhost:8001/v1/models/Systran/faster-whisper-small
+```
+
+### TTS — Kokoro
+
+```bash
+docker run -d -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-cpu:latest
+```
+
+Kokoro-82M is small enough to run comfortably on CPU.
+
+### Or bring them all up with the `local` profile
+
+```bash
+docker compose --profile local --profile live up
+```
+
+This starts Ollama (+ a one-shot model pull), the Whisper server and Kokoro
+alongside the app. On a Mac, prefer the native Ollama above and point the
+containers at it with `OLLAMA_BASE_URL=http://host.docker.internal:11434/v1`.
+
+---
+
+## 2. Configure
+
+`pnpm deepinterview init` → **"100% local models"** sets all of this for you.
+Or write it yourself:
+
+```bash
+LLM_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_MODEL=qwen3:8b
+
+STT_PROVIDER=whisper
+WHISPER_BASE_URL=http://localhost:8001/v1
+
+TTS_PROVIDER=kokoro
+KOKORO_BASE_URL=http://localhost:8880/v1
+KOKORO_MODEL=tts-1        # do not change — see below
+KOKORO_VOICE=             # blank = pick the voice from the session language
+
+# Company research is the one remaining outbound call. Mock it for a fully
+# offline run; leave it on Tavily/Exa if you want real company intel.
+SEARCH_PROVIDER=mock
+
+# Local models are slower than cloud ones. Without these, prep and scoring hit
+# their ceilings and silently degrade to generic results.
+LLM_CALL_TIMEOUT_SEC=300
+SCORE_STAGE_TIMEOUT_SEC=300
+```
+
+**`KOKORO_MODEL=tts-1` is load-bearing.** That id is what selects the raw-audio
+transport in the OpenAI plugin; any other value routes synthesis down a
+server-sent-events branch that yields **no audio and no error** — the agent
+simply never speaks. `kokoro-fastapi` ignores the model name itself, so pinning
+it costs nothing. The worker coerces a wrong value back to `tts-1` and logs a
+warning rather than going silent.
+
+---
+
+## 3. Known differences from the cloud path
+
+These are consequences of the design, not bugs. They are listed here so the
+local path isn't oversold.
+
+| | Cloud path | Local path |
+|---|---|---|
+| **Live captions** | word-by-word | **per utterance** — the OpenAI-compatible STT is a batch endpoint, so the worker VAD-segments your speech and transcribes each chunk. There are no interim results. |
+| **Barge-in** | word-gated on interim transcripts | fires later, since the gate can only run once a whole utterance is transcribed |
+| **Voice languages** | 7+, incl. Vietnamese | **Kokoro has no Vietnamese voice.** A `vi` session with `TTS_PROVIDER=kokoro` honestly falls through to a cloud voice rather than reading Vietnamese with an American accent. Kokoro covers en, ja, zh, es, fr, hi, it, pt. |
+| **Turn latency** | tuned and measured | **not benchmarked.** It depends heavily on your hardware and model size. |
+| **CI coverage** | mock adapters, every PR | the local path is **maintainer-verified, not CI-tested** — CI has no models. |
+
+Because Kokoro encodes the language in the voice-id prefix (`af_`/`am_` = American
+English, `bf_` = British, `jf_` = Japanese, `zf_` = Chinese, `ef_` = Spanish,
+`ff_` = French, `hf_` = Hindi, `if_` = Italian, `pf_` = Portuguese), picking a
+voice *is* picking a language. Leave `KOKORO_VOICE` blank and the session
+language chooses; set it to pin one.
+
+---
+
+## 4. What we verified
+
+On an Apple M5 Pro (24 GB), Ollama 0.32.5 + `qwen3:8b`, Speaches
+(`faster-whisper-small`) and kokoro-fastapi, all on CPU/Metal locally:
+
+- **Prep → question plan on the local LLM: 121s.** Six questions, difficulty
+  ramping 1→5, each grounded in the specific CV and job description — it asked
+  about Postgres logical replication from the CV and Rust from the JD — with
+  zero degraded stages and no fallback to the generic plan.
+- **TTS → STT round trip through the real worker builders.** Kokoro synthesized
+  *"Tell me about a hard bug you fixed in a payment system."* into 3.25s of PCM
+  at 24 kHz, and the Whisper server transcribed that audio back **verbatim**.
+  This exercises the exact code path the live worker uses, so it rules out both
+  silent failure modes (the no-audio SSE branch and an empty transcript).
+- Provider selection, fallback, and the language/voice routing are covered by
+  unit tests that run with no models installed.
+
+**Not verified, and therefore not claimed:** turn latency, barge-in feel, and a
+full microphone-in-a-LiveKit-room session — that last one needs a human to speak,
+so it is not something CI or a scripted check can stand in for. Non-English local
+voice is untested, as is any hardware other than the above.
+
+## 5. When it goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Interview asks one question titled **"mock"** | the model's JSON didn't parse, so the planner fell back | check the agent log for `question_planner failed, using minimal generic plan`; try a larger model |
+| A plausible plan that mentions **nothing from your CV** | context window truncated the prompt | set `OLLAMA_CONTEXT_LENGTH=16384` |
+| Agent **never speaks**, no error | `KOKORO_MODEL` isn't `tts-1` | set it back; check the worker log for the coercion warning |
+| Speech is **chipmunk or slow-motion** | your TTS server isn't returning 24 kHz audio | the plugin decodes at a fixed 24 kHz; Kokoro's native rate already matches |
+| Agent **never hears you** | Whisper server unreachable or rejecting requests | the worker refuses to start a session against an unreachable local server and names the URL + env var; check that error first |
+| Turns die after ~10s | per-request ceiling | handled automatically — selecting any local provider widens it to 30s (`LOCAL_PROVIDER_TIMEOUT_SEC`) |
+
+---
+
+## Related work
+
+If you want a **pure local voice pipeline** rather than a full interview
+platform, look at [`huggingface/speech-to-speech`](https://github.com/huggingface/speech-to-speech)
+(Apache-2.0) — Hugging Face's cascaded VAD → STT → LLM → TTS stack, with MLX
+support on Apple Silicon and an OpenAI Realtime-compatible WebSocket API. It is
+the closest sibling to this page's setup and a great starting point if you're
+assembling your own local speech loop.
+
+It is **not** wired in as a provider here, and the reason is worth stating: it
+exposes only a complete speech-to-speech session (`/v1/realtime`) — no
+`/v1/audio/transcriptions`, no `/v1/audio/speech`, and no way to disable its LLM
+stage. DeepInterview needs to own the LLM turn itself (the interviewer calls
+`save_answer` / `get_next_question`, and an adaptive Director sits behind it), so
+a black-box pipeline that answers for us can't slot into the cascade. If it ever
+grows a transcription-only session mode, it would drop straight into
+`STT_PROVIDER`.

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -62,8 +62,28 @@ docker run -d -p 8001:8000 ghcr.io/speaches-ai/speaches:latest-cpu
 
 # Speaches ships no weights — download the model once, or every transcription
 # 404s with "Model ... is not installed locally".
-curl -X POST http://localhost:8001/v1/models/Systran/faster-whisper-small
+curl -X POST http://localhost:8001/v1/models/Systran/faster-whisper-base
 ```
+
+**Pick the smallest Whisper that's accurate enough — this matters more than it
+looks.** The OpenAI plugin hard-codes a **30-second per-request timeout that no
+setting can raise**, so a slow transcription doesn't degrade gracefully; the turn
+dies with `failed to recognize speech`. Measured on an M5 Pro with the local LLM
+generating at the same time — the condition that actually holds mid-interview,
+since the next utterance is transcribed while the agent is still replying:
+
+| Model | Idle | Under LLM load | Resident |
+|---|---|---|---|
+| `faster-whisper-tiny.en` | 0.06× realtime | 0.13× | very small |
+| **`faster-whisper-base`** (default) | 0.09× | ~0.7× | **~220 MB** |
+| `faster-whisper-small` | 0.40× | 0.77× | **~3.4 GB** |
+
+Accuracy on interview speech was indistinguishable across all three, so `small`
+bought nothing and cost 15× the memory. It first showed up as a hang, not a
+slowdown: inside a memory-constrained Docker VM (Docker Desktop defaults to a
+fraction of host RAM, shared by *every* container you're running) `small` pushed
+the VM into swap and a 3.6-second clip took **32 seconds**. Use `small` or
+`medium` only with a GPU.
 
 ### TTS — Kokoro
 
@@ -174,6 +194,7 @@ voice is untested, as is any hardware other than the above.
 | Agent **never speaks**, no error | `KOKORO_MODEL` isn't `tts-1` | set it back; check the worker log for the coercion warning |
 | Speech is **chipmunk or slow-motion** | your TTS server isn't returning 24 kHz audio | the plugin decodes at a fixed 24 kHz; Kokoro's native rate already matches |
 | Agent **never hears you** | Whisper server unreachable or rejecting requests | the worker refuses to start a session against an unreachable local server and names the URL + env var; check that error first |
+| `failed to recognize speech after N attempts` in the worker log | transcription exceeded the plugin's fixed 30s ceiling — almost always too large a Whisper model, or memory pressure in the Docker VM | drop to `WHISPER_MODEL=Systran/faster-whisper-base` (or `tiny.en`); check `docker stats` for a server holding multiple GB, and raise Docker Desktop's memory allocation |
 | Turns die after ~10s | per-request ceiling | handled automatically — selecting any local provider widens it to 30s (`LOCAL_PROVIDER_TIMEOUT_SEC`) |
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepinterview",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Open-source (Apache-2.0), voice-first AI mock-interview platform. English-first, multilingual.",
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepinterview/shared",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/services/lightrag/pyproject.toml
+++ b/services/lightrag/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepinterview-lightrag"
-version = "0.2.0"
+version = "0.3.0"
 description = "DeepInterview knowledge sidecar — NaiveRAG by default, LightRAG + RAG-Anything + bge-m3 as an optional extra (WP-8)."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/services/lightrag/uv.lock
+++ b/services/lightrag/uv.lock
@@ -712,7 +712,7 @@ nvtx = [
 
 [[package]]
 name = "deepinterview-lightrag"
-version = "0.0.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes #55, closes #56, closes #57.

An interview can now run with **no LLM, STT or TTS key at all**:

```bash
LLM_PROVIDER=ollama  STT_PROVIDER=whisper  TTS_PROVIDER=kokoro
```

All three speak the OpenAI HTTP shape, so this reuses the already-installed
`livekit-plugins-openai` with a `base_url` override — **no new dependency, no new
extra, no Docker image change**. Any compatible server works (Ollama, vLLM,
LM Studio, llama.cpp, Speaches, kokoro-fastapi).

Also ships: a `deepinterview init` → **"100% local models"** mode, a
`docker compose --profile local` stack, and `docs/LOCAL_MODELS.md`.

## Five silent failures this had to design around

Each fails with **no error and no log** — the kind that ships looking fine.

1. **The agent goes mute.** `openai.TTS` routes synthesis down an SSE branch
   unless the model id is in `AUDIO_STREAM_MODELS`; raw audio matches nothing
   there, so it emits zero frames and raises nothing. Kokoro is pinned to
   `tts-1`, and a wrong value is coerced with a warning.
2. **The STT client isn't streaming.** `openai.STT` is batch-mode, so it's
   wrapped in `StreamAdapter` with the prewarmed Silero VAD. Documented
   consequence: no interim transcripts locally.
3. **Code-switching sent a Deepgram model name to Whisper.** `_stt_lang` returns
   `"multi"`, which Whisper rejects — zero transcripts, the same failure class as
   the earlier nova-3 + `vi` bug. The local branch uses `detect_language`.
4. **Every turn died at 10 seconds.** `APIConnectOptions.timeout` defaults to
   10s; a cold `qwen3:8b` took **11.3s** on a one-line prompt. Selecting a local
   provider widens it to 30s; the cloud path is untouched.
5. **Whisper `small` blew a ceiling that can't be raised.** Found on real
   hardware — see below.

Plus: Qwen3 emits `<think>` blocks inline, and the JSON parser took the first
`{` it saw, which could be a brace from the scratchpad. Now stripped first.

## Whisper default: `base`, not `small`

The plugin hard-codes a **30s read timeout no setting can raise**, so an
oversized model doesn't degrade — it kills the turn. Measured with the LLM
generating concurrently (the real mid-interview condition):

| Model | Idle | Under LLM load | Resident |
|---|---|---|---|
| `tiny.en` | 0.06× realtime | 0.13× | very small |
| **`base`** (default) | 0.09× | ~0.7× | **~220 MB** |
| `small` | 0.40× | 0.77× | **~3.4 GB** |

Accuracy was indistinguishable on interview speech. In a memory-tight Docker VM
`small` pushed the VM into swap and a 3.6s clip took **32 seconds**.

## Verified

On an Apple M5 Pro (24 GB), `qwen3:8b` + Speaches + kokoro-fastapi:

- **Prep → question plan: 121–144s.** Real, CV-grounded questions with difficulty
  ramping 1→5 and zero degraded stages — it asked about Postgres logical
  replication from the CV and Rust from the JD, which also proves the context
  window wasn't truncating.
- **Kokoro → Whisper round trip through the real worker builders**: 3.25s of PCM
  at exactly 24 kHz, transcribed back verbatim. Rules out both silent failure
  modes above.
- 215 pytest + 26 vitest + lint + schema parity + compose (all profiles) + agent
  image build, all green. 20 livekit-coupled tests pass locally — CI skips these,
  and they're the ones covering this change.

## Not verified — and not claimed anywhere

- **Turn latency is not benchmarked.** No number is published.
- **A full microphone session has not yet completed end to end.** Tuning local
  turn latency is follow-up work.
- **Kokoro has no Vietnamese voice** — `vi` honestly falls back to a cloud voice
  rather than mispronouncing it.
- **LiveKit remains the transport.** The claim is "no cloud *model* keys", never
  "no cloud"; `livekit-server --dev` is documented for a fully offline stack.
- **CI has no models**, so the local path is maintainer-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)