### PR TITLE
docs(local): link the OpenRouter/CPU-only guide; document LOCAL_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,11 @@ OPENAI_API_KEY=
 # Swapping servers means changing a URL and a model name — never code.
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen3:8b
+# Local servers need no auth, so this is a placeholder the OpenAI client
+# requires (it raises on an empty key). It becomes a REAL credential if you
+# point OLLAMA_BASE_URL at a hosted OpenAI-compatible gateway such as
+# OpenRouter — see docs/OPENROUTER_AND_CPU_ONLY.md.
+LOCAL_API_KEY=local
 WHISPER_BASE_URL=http://localhost:8000/v1
 # `base` is the CPU-safe default. Bigger Whisper models blow through the
 # 30s per-request ceiling on CPU (especially in a memory-tight Docker VM) and

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Cloud, or `livekit-server --dev` for a fully offline stack), and local STT is
 batch, so captions appear per utterance rather than word by word. Turn latency
 on local models is not benchmarked, and Kokoro has no Vietnamese voice.
 Full setup, hardware notes and troubleshooting: **[docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md)**.
+Running against a hosted OpenAI-compatible gateway instead (OpenRouter and
+friends), or stuck on a **CPU-only machine** where the voice stack won't fit?
+See [docs/OPENROUTER_AND_CPU_ONLY.md](docs/OPENROUTER_AND_CPU_ONLY.md).
 
 > **Language routing is automatic — not something you configure.** If your chosen TTS doesn't cover the session language (e.g., Vietnamese on Cartesia), the agent reroutes that session to ElevenLabs or Gemini TTS when a key is present. Cartesia covers en, es, zh, fr, de, ja, pt, hi, it, ko, nl, pl, ru, sv, tr; Deepgram nova-3 covers English + many languages (Vietnamese validation in progress).
 

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -247,6 +247,21 @@ you can name what you actually run (or just say `local`).
 *(verified)* means it was run end to end for the v0.3.0 release; the others
 implement the same endpoint but haven't been exercised here.
 
+### The contract also reaches remote gateways
+
+"OpenAI-format endpoint over a base URL" doesn't have to mean *local*. Point
+`OLLAMA_BASE_URL` at a hosted OpenAI-compatible gateway — OpenRouter, Together,
+Groq, your own vLLM box — and the same `ollama`/`vllm`/`local` providers drive it
+unchanged. You trade the privacy property for someone else's GPU: prompts (CV
+text, JD, answers) leave your machine.
+
+That path has its own failure modes worth reading before you debug them — free
+model slugs that rate-limit, and reasoning models that emit chain-of-thought
+*before* the JSON the prep pipeline parses, which degrades the question plan to a
+generic one without erroring. Both, plus what still works on a **CPU-only
+machine** that can't run the live voice stack, are covered in
+[`OPENROUTER_AND_CPU_ONLY.md`](OPENROUTER_AND_CPU_ONLY.md).
+
 ### Qwen3-ASR instead of Whisper
 
 [Qwen3-ASR](https://github.com/QwenLM/Qwen3-ASR) (Alibaba, 52 languages) is a


### PR DESCRIPTION
## Why
Follow-up to #68, as promised in review. That PR landed a genuinely useful guide, but nothing linked to it, and `LOCAL_API_KEY` was documented *only* there — despite being the one local-path env var that stops being a placeholder the moment your base URL is remote.

## What
- **`docs/LOCAL_MODELS.md`** — a *"the contract also reaches remote gateways"* subsection under the compatibility table. That table already claims "a contract, not a vendor"; this just points the claim at someone else's GPU and names the trade (prompts leave your machine) instead of leaving it implied.
- **`.env.example`** — `LOCAL_API_KEY=local`, matching the Python default at `core/config.py:93`, with the note about when it becomes a real credential.
- **`README.md`** — pointer from the local-models section.

Docs + env template only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)