### PR TITLE
feat(local): two model tiers — a smaller model on the turn loop only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,11 @@ OPENAI_API_KEY=
 # Swapping servers means changing a URL and a model name — never code.
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen3:8b
+# Local servers need no auth, so this is a placeholder the OpenAI client
+# requires (it raises on an empty key). It becomes a REAL credential if you
+# point OLLAMA_BASE_URL at a hosted OpenAI-compatible gateway such as
+# OpenRouter — see docs/OPENROUTER_AND_CPU_ONLY.md.
+LOCAL_API_KEY=local
 WHISPER_BASE_URL=http://localhost:8000/v1
 # `base` is the CPU-safe default. Bigger Whisper models blow through the
 # 30s per-request ceiling on CPU (especially in a memory-tight Docker VM) and

--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,12 @@ OPENAI_API_KEY=
 # Swapping servers means changing a URL and a model name — never code.
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen3:8b
+# Optional second tier for the LIVE turn loop only (prep + scoring stay on
+# OLLAMA_MODEL). Blank = use the same model for both, which is the old
+# behaviour. Point it at a SMALLER model you have already pulled to cut
+# time-to-first-token mid-conversation, e.g. qwen3:1.7b. A model you have not
+# pulled 404s the turn path, so this stays opt-in. See docs/LOCAL_MODELS.md.
+OLLAMA_MODEL_LIVE=
 # Local servers need no auth, so this is a placeholder the OpenAI client
 # requires (it raises on an empty key). It becomes a REAL credential if you
 # point OLLAMA_BASE_URL at a hosted OpenAI-compatible gateway such as

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Cloud, or `livekit-server --dev` for a fully offline stack), and local STT is
 batch, so captions appear per utterance rather than word by word. Turn latency
 on local models is not benchmarked, and Kokoro has no Vietnamese voice.
 Full setup, hardware notes and troubleshooting: **[docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md)**.
+Running against a hosted OpenAI-compatible gateway instead (OpenRouter and
+friends), or stuck on a **CPU-only machine** where the voice stack won't fit?
+See [docs/OPENROUTER_AND_CPU_ONLY.md](docs/OPENROUTER_AND_CPU_ONLY.md).
 
 > **Language routing is automatic — not something you configure.** If your chosen TTS doesn't cover the session language (e.g., Vietnamese on Cartesia), the agent reroutes that session to ElevenLabs or Gemini TTS when a key is present. Cartesia covers en, es, zh, fr, de, ja, pt, hi, it, ko, nl, pl, ru, sv, tr; Deepgram nova-3 covers English + many languages (Vietnamese validation in progress).
 

--- a/apps/agent/src/deepinterview_agent/core/config.py
+++ b/apps/agent/src/deepinterview_agent/core/config.py
@@ -60,6 +60,17 @@ class Settings(BaseSettings):
     # TTS_PROVIDER=kokoro; each needs its base URL, never an API key.
     ollama_base_url: str = "http://localhost:11434/v1"
     ollama_model: str = "qwen3:8b"
+    # Live tier, mirroring gemini_model / gemini_model_live: prep and scoring can
+    # afford a bigger model because nobody is waiting mid-sentence; the turn loop
+    # cannot. A smaller model here buys time-to-first-token on every turn.
+    #
+    # Deliberately EMPTY rather than a smaller default: unlike a cloud tier, the
+    # live model has to already be pulled on this machine. Defaulting to
+    # something like qwen3:4b would 404 the turn path for everyone who pulled
+    # only qwen3:8b — the "it worked yesterday" upgrade break. Empty means "same
+    # model as prep", so the local path behaves exactly as before until you opt
+    # in. Override: OLLAMA_MODEL_LIVE.
+    ollama_model_live: str = ""
     whisper_base_url: str = "http://localhost:8000/v1"
     # `base` (multilingual), NOT `small`. Measured on an M5 Pro with the LLM
     # generating concurrently — the condition that actually holds mid-interview,

--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -325,8 +325,18 @@ def build_llm(settings):
         from livekit.plugins import openai
 
         # Local LLM on the turn path via Ollama's OpenAI-compatible endpoint.
+        # Live tier when set (see Settings.ollama_model_live): the prep model is
+        # sized for a pipeline nobody is waiting on, the turn loop is not.
+        # Falling back to ollama_model keeps the un-tuned path byte-identical.
+        model = settings.ollama_model_live or settings.ollama_model
+        if settings.ollama_model_live:
+            log.info(
+                "build_llm: local live tier — turn path on %r (prep/scoring stays on %r)",
+                settings.ollama_model_live,
+                settings.ollama_model,
+            )
         return openai.LLM(
-            model=settings.ollama_model,
+            model=model,
             base_url=settings.ollama_base_url,
             api_key=settings.local_api_key,
         )

--- a/apps/agent/tests/test_worker_livekit.py
+++ b/apps/agent/tests/test_worker_livekit.py
@@ -607,6 +607,7 @@ def _local_settings(**overrides):
         "tts_provider": "mock",
         "ollama_base_url": "http://localhost:11434/v1",
         "ollama_model": "qwen3:8b",
+        "ollama_model_live": "",
         "whisper_base_url": "http://localhost:8000/v1",
         "whisper_model": "Systran/faster-whisper-small",
         "kokoro_base_url": "http://localhost:8880/v1",
@@ -635,6 +636,35 @@ def test_build_llm_ollama_points_at_local_server() -> None:
     pytest.importorskip("livekit.plugins.openai")
     llm = worker.build_llm(_local_settings(llm_provider="ollama"))
     assert str(llm._client.base_url).startswith("http://localhost:11434")
+    assert llm._opts.model == "qwen3:8b"
+
+
+def test_build_llm_local_live_tier_overrides_the_prep_model() -> None:
+    """OLLAMA_MODEL_LIVE must win on the turn path when it is set.
+
+    The prep model is sized for a pipeline nobody is waiting on; the live loop
+    needs time-to-first-token. If this override is ever dropped, the split
+    silently collapses back to one model and the latency work is undone with no
+    error to notice.
+    """
+    pytest.importorskip("livekit.plugins.openai")
+    llm = worker.build_llm(
+        _local_settings(llm_provider="ollama", ollama_model_live="qwen3:1.7b")
+    )
+    assert llm._opts.model == "qwen3:1.7b"
+    assert str(llm._client.base_url).startswith("http://localhost:11434")
+
+
+def test_build_llm_local_live_tier_falls_back_when_unset() -> None:
+    """Unset means "same model as prep" — never an empty model id.
+
+    The default is empty on purpose (a smaller default would 404 for anyone who
+    pulled only the prep model), so the fallback is what keeps every existing
+    local install working. Passing "" through to the plugin would break the
+    turn path for exactly the users who changed nothing.
+    """
+    pytest.importorskip("livekit.plugins.openai")
+    llm = worker.build_llm(_local_settings(llm_provider="ollama", ollama_model_live=""))
     assert llm._opts.model == "qwen3:8b"
 
 

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -117,6 +117,14 @@ async function collectLlm(existing: Values, values: Values): Promise<void> {
       existing.OLLAMA_MODEL || "qwen3:8b",
       "qwen3:8b",
     );
+    // Optional second tier for the turn loop. Blank stays blank: the worker
+    // reads that as "same model as prep", and a model the user has not pulled
+    // would 404 every turn.
+    values.OLLAMA_MODEL_LIVE = await field(
+      "Live-interview model (optional — blank = same as above; a smaller one answers faster)",
+      existing.OLLAMA_MODEL_LIVE ?? "",
+      "e.g. qwen3:1.7b",
+    );
   }
 }
 
@@ -298,6 +306,14 @@ async function runWizard(existing: Values): Promise<Values> {
       "Ollama model",
       existing.OLLAMA_MODEL || "qwen3:8b",
       "qwen3:8b",
+    );
+    // Optional second tier for the turn loop. Blank stays blank: the worker
+    // reads that as "same model as prep", and a model the user has not pulled
+    // would 404 every turn.
+    values.OLLAMA_MODEL_LIVE = await field(
+      "Live-interview model (optional — blank = same as above; a smaller one answers faster)",
+      existing.OLLAMA_MODEL_LIVE ?? "",
+      "e.g. qwen3:1.7b",
     );
     values.WHISPER_BASE_URL = await field(
       "Whisper server base URL (OpenAI-compatible)",

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -114,6 +114,7 @@ Or write it yourself:
 LLM_PROVIDER=ollama
 OLLAMA_BASE_URL=http://localhost:11434/v1
 OLLAMA_MODEL=qwen3:8b
+OLLAMA_MODEL_LIVE=        # optional; blank = same model live as in prep
 
 STT_PROVIDER=whisper
 WHISPER_BASE_URL=http://localhost:8001/v1
@@ -140,6 +141,37 @@ simply never speaks. `kokoro-fastapi` ignores the model name itself, so pinning
 it costs nothing. The worker coerces a wrong value back to `tts-1` and logs a
 warning rather than going silent.
 
+### Two model tiers: prep and live
+
+`OLLAMA_MODEL` runs the **prep pipeline and scoring**; `OLLAMA_MODEL_LIVE`, if
+set, runs the **live turn loop** instead. The two jobs have opposite constraints:
+
+- **Prep and scoring** are batch. They take minutes, nobody is waiting
+  mid-sentence, and quality shows up directly in the question plan — this is
+  where a bigger model earns its keep.
+- **The live loop** is judged on *time-to-first-token*. Every second before the
+  interviewer starts speaking is a second of dead air in a conversation, and a
+  model that reasons at length before its first word feels broken even when the
+  answer is good.
+
+This mirrors what the cloud path already does with `GEMINI_MODEL` /
+`GEMINI_MODEL_LIVE` (analytic Flash for prep, Flash-Lite for the turn loop).
+
+```bash
+OLLAMA_MODEL=qwen3:8b          # prep + scoring: quality
+OLLAMA_MODEL_LIVE=qwen3:1.7b   # turn loop: latency
+```
+
+**Blank is the default, and that is deliberate.** Unlike a cloud tier, the live
+model has to already be pulled on your machine — a default you never pulled
+would 404 every turn. Blank means "same model as prep", so nothing changes until
+you opt in. `ollama pull` the smaller model first, then set it.
+
+The trade is real in both directions: a smaller live model is quicker to speak
+but calls the `save_answer` tool less reliably (see §4). The shutdown-time
+transcript recovery catches that, so the report stays correct — but if you go
+very small, check the worker log for `recovered N answer(s) from transcript`.
+
 ---
 
 ## 3. Known differences from the cloud path
@@ -152,7 +184,7 @@ local path isn't oversold.
 | **Live captions** | word-by-word | **per utterance** — the OpenAI-compatible STT is a batch endpoint, so the worker VAD-segments your speech and transcribes each chunk. There are no interim results. |
 | **Barge-in** | word-gated on interim transcripts | fires later, since the gate can only run once a whole utterance is transcribed |
 | **Voice languages** | 7+, incl. Vietnamese | **Kokoro has no Vietnamese voice.** A `vi` session with `TTS_PROVIDER=kokoro` honestly falls through to a cloud voice rather than reading Vietnamese with an American accent. Kokoro covers en, ja, zh, es, fr, hi, it, pt. |
-| **Turn latency** | tuned and measured | **not benchmarked.** It depends heavily on your hardware and model size. |
+| **Turn latency** | tuned and measured | **not benchmarked.** It depends heavily on your hardware and model size. `OLLAMA_MODEL_LIVE` is the lever — a smaller model on the turn loop only (see §2). |
 | **CI coverage** | mock adapters, every PR | the local path is **maintainer-verified, not CI-tested** — CI has no models. |
 
 Because Kokoro encodes the language in the voice-id prefix (`af_`/`am_` = American

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -247,6 +247,21 @@ you can name what you actually run (or just say `local`).
 *(verified)* means it was run end to end for the v0.3.0 release; the others
 implement the same endpoint but haven't been exercised here.
 
+### The contract also reaches remote gateways
+
+"OpenAI-format endpoint over a base URL" doesn't have to mean *local*. Point
+`OLLAMA_BASE_URL` at a hosted OpenAI-compatible gateway — OpenRouter, Together,
+Groq, your own vLLM box — and the same `ollama`/`vllm`/`local` providers drive it
+unchanged. You trade the privacy property for someone else's GPU: prompts (CV
+text, JD, answers) leave your machine.
+
+That path has its own failure modes worth reading before you debug them — free
+model slugs that rate-limit, and reasoning models that emit chain-of-thought
+*before* the JSON the prep pipeline parses, which degrades the question plan to a
+generic one without erroring. Both, plus what still works on a **CPU-only
+machine** that can't run the live voice stack, are covered in
+[`OPENROUTER_AND_CPU_ONLY.md`](OPENROUTER_AND_CPU_ONLY.md).
+
 ### Qwen3-ASR instead of Whisper
 
 [Qwen3-ASR](https://github.com/QwenLM/Qwen3-ASR) (Alibaba, 52 languages) is a


### PR DESCRIPTION
Addresses the two-tier item of #66.

> **Stacked on #69** (docs-only). Both touch `.env.example`; merge #69 first and this diff reduces to the change described below.

## The problem
Prep and the live turn loop have opposite constraints, and the local path ran both on one model:

- **Prep + scoring** are batch. Minutes are fine, nobody is waiting mid-sentence, and quality shows up directly in the question plan. A bigger model earns its keep.
- **The live loop** is judged on *time-to-first-token*. A model that reasons at length before its first word reads as broken even when the answer is good.

The cloud path has split these since day one — `GEMINI_MODEL` (analytic Flash) vs `GEMINI_MODEL_LIVE` (Flash-Lite). The local path had no equivalent.

## The change
`OLLAMA_MODEL_LIVE` runs the turn loop when set; `OLLAMA_MODEL` keeps prep and scoring.

```bash
OLLAMA_MODEL=qwen3:8b          # prep + scoring: quality
OLLAMA_MODEL_LIVE=qwen3:1.7b   # turn loop: latency
```

**The default is empty, not a smaller model.** Unlike a cloud tier, the live model has to already be pulled on the user's machine — defaulting to something like `qwen3:4b` would 404 the turn path for everyone who pulled only `qwen3:8b`, breaking installs that changed nothing. Blank reads as "same model as prep", so the un-tuned path is byte-identical to before.

- `core/config.py` — `ollama_model_live: str = ""`
- `worker.py` — `build_llm` prefers it, logs the split when active
- two tests — the override wins; unset falls back rather than passing `""` to the plugin
- `.env.example`, `docs/LOCAL_MODELS.md` (new "Two model tiers" section), and the `deepinterview init` wizard, which now offers it with a blank default

Documented honestly in both directions: a smaller live model speaks sooner but calls `save_answer` less reliably, which leans harder on the existing shutdown-time transcript recovery.

## Verification
`pnpm lint` (prettier + ruff), `pnpm typecheck`, `pnpm test` — **218 agent tests pass**, including the two new ones. The latency benefit itself is *not* benchmarked here; that is the separate open item in #66 and needs hardware runs.

## Still open in #66
End-to-end turn timing across hardware profiles · endpointing tuning for the no-interim-transcript case · whether `tiny.en` should be the English default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)