### PR TITLE
feat(skills): 26 generic role packs — library from 4 to 30

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -15,9 +15,35 @@ promoted from real interview runs (`{company} × {role} × {level}`).
 <!-- PACK-INDEX:START — generated, do not edit by hand -->
 | Pack | Company | Role | Level | Status | Confidence | Questions | Verified |
 |---|---|---|---|---|---|---|---|
+| [generic-ai-engineer-senior](./generic-ai-engineer-senior.md) | generic | ai-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-android-engineer-mid](./generic-android-engineer-mid.md) | generic | android-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-backend-engineer-junior](./generic-backend-engineer-junior.md) | generic | backend-engineer | junior | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-backend-engineer-mid](./generic-backend-engineer-mid.md) | generic | backend-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
 | [generic-backend-engineer-senior](./generic-backend-engineer-senior.md) | generic | backend-engineer | senior | promoted | 0.50 | 7 | 2026-07-25 |
+| [generic-backend-engineer-staff](./generic-backend-engineer-staff.md) | generic | backend-engineer | staff | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-data-engineer-mid](./generic-data-engineer-mid.md) | generic | data-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-data-engineer-senior](./generic-data-engineer-senior.md) | generic | data-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-data-scientist-mid](./generic-data-scientist-mid.md) | generic | data-scientist | mid | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-devops-engineer-mid](./generic-devops-engineer-mid.md) | generic | devops-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-engineering-manager-senior](./generic-engineering-manager-senior.md) | generic | engineering-manager | senior | promoted | 0.50 | 9 | 2026-08-26 |
+| [generic-frontend-engineer-junior](./generic-frontend-engineer-junior.md) | generic | frontend-engineer | junior | promoted | 0.50 | 7 | 2026-08-26 |
 | [generic-frontend-engineer-mid](./generic-frontend-engineer-mid.md) | generic | frontend-engineer | mid | promoted | 0.50 | 7 | 2026-07-25 |
+| [generic-frontend-engineer-senior](./generic-frontend-engineer-senior.md) | generic | frontend-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-full-stack-engineer-mid](./generic-full-stack-engineer-mid.md) | generic | full-stack-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-full-stack-engineer-senior](./generic-full-stack-engineer-senior.md) | generic | full-stack-engineer | senior | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-ios-engineer-senior](./generic-ios-engineer-senior.md) | generic | ios-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-machine-learning-engineer-mid](./generic-machine-learning-engineer-mid.md) | generic | machine-learning-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-machine-learning-engineer-senior](./generic-machine-learning-engineer-senior.md) | generic | machine-learning-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-mobile-engineer-mid](./generic-mobile-engineer-mid.md) | generic | mobile-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-platform-engineer-senior](./generic-platform-engineer-senior.md) | generic | platform-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-product-manager-mid](./generic-product-manager-mid.md) | generic | product-manager | mid | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-qa-engineer-mid](./generic-qa-engineer-mid.md) | generic | qa-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-security-engineer-senior](./generic-security-engineer-senior.md) | generic | security-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-site-reliability-engineer-senior](./generic-site-reliability-engineer-senior.md) | generic | site-reliability-engineer | senior | promoted | 0.50 | 8 | 2026-08-26 |
+| [generic-software-engineer-intern](./generic-software-engineer-intern.md) | generic | software-engineer | intern | promoted | 0.50 | 7 | 2026-08-26 |
 | [generic-software-engineer-junior](./generic-software-engineer-junior.md) | generic | software-engineer | junior | promoted | 0.50 | 7 | 2026-07-25 |
+| [generic-software-engineer-mid](./generic-software-engineer-mid.md) | generic | software-engineer | mid | promoted | 0.50 | 7 | 2026-08-26 |
+| [generic-technical-program-manager-senior](./generic-technical-program-manager-senior.md) | generic | technical-program-manager | senior | promoted | 0.50 | 8 | 2026-08-26 |
 | [examplecorp-backend-senior](./example-corp-backend-senior.md) | ExampleCorp | backend-engineer | senior | draft | 0.30 | 2 | 2026-06-08 |
 <!-- PACK-INDEX:END -->
 

--- a/skills/generic-ai-engineer-senior.md
+++ b/skills/generic-ai-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-ai-engineer-senior
+company: generic
+role: ai-engineer
+level: senior
+competency:
+  - llm-application-design
+  - evaluation
+  - retrieval
+  - cost-and-latency
+  - product-judgment
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior AI Engineer (LLM Applications)
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on an LLM feature they shipped to users (14m)
+2. Design an LLM-backed product feature with evaluation and guardrails (20m)
+3. Cost, latency and failure-mode judgment (11m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about an LLM feature you shipped. What did real users do that you didn't expect?"
+- "Design a support assistant over a company's documentation. How do you know it's good enough to launch?"
+- "How do you build an evaluation set when there's no ground truth to start from?"
+- "Your assistant is confidently wrong 5% of the time. What are your options, and what do they cost?"
+- "When is retrieval the answer, when is fine-tuning, and when is neither?"
+- "How do you keep prompt changes from silently regressing behavior?"
+- "Where do you put a human in the loop, and how do you decide?"
+- "How do you handle latency when the model is the slow part of the request?"
+
+## Signals
+- Builds evaluation before scaling the feature, and treats evals as a product asset.
+- Reasons about failure modes in user terms — wrong, refused, slow, unsafe — not just model metrics.
+- Treats prompts and retrieval as versioned, tested artifacts rather than editable strings.
+- Knows when a deterministic system beats a model and says so.
+
+## Pitfalls
+- Demo-driven development with no measurement of the failure rate.
+- Adds retrieval reflexively without checking whether the model already knows the answer.
+- No guardrails for the case where the model is wrong, only for where it's unsafe.
+- Cannot say what the feature costs per request or what it would cost at 100x.

--- a/skills/generic-android-engineer-mid.md
+++ b/skills/generic-android-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-android-engineer-mid
+company: generic
+role: android-engineer
+level: mid
+competency:
+  - kotlin
+  - android-platform
+  - architecture
+  - performance
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Android Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on an Android app they've worked on (12m)
+2. Feature design with lifecycle and process-death constraints (18m)
+3. Performance, fragmentation and release practice (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about an Android app you worked on. What was hardest about the device landscape?"
+- "Design a screen that survives rotation, process death, and a cold start from a notification."
+- "How do you keep work off the main thread in Kotlin, and what have you gotten wrong there?"
+- "An ANR shows up only on low-end devices. How do you chase it?"
+- "How do you decide what belongs in a ViewModel versus a repository?"
+- "What's your approach to background work that must eventually run?"
+- "How do you handle a permission the user has permanently denied?"
+
+## Signals
+- Treats the activity/process lifecycle as a first-class design input, not trivia.
+- Tests on realistic hardware and knows what low-end actually means for their app.
+- Uses structured concurrency deliberately, with cancellation in mind.
+- Understands background execution limits rather than fighting them.
+
+## Pitfalls
+- Stores UI state where it cannot survive a configuration change, then patches symptoms.
+- Assumes a flagship device and a fast network.
+- Cannot explain what happens when the system kills their process.
+- Requests permissions upfront with no context for the user.

--- a/skills/generic-backend-engineer-junior.md
+++ b/skills/generic-backend-engineer-junior.md
@@ -1,0 +1,48 @@
+---
+id: generic-backend-engineer-junior
+company: generic
+role: backend-engineer
+level: junior
+competency:
+  - fundamentals
+  - debugging
+  - code-quality
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Junior Backend Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Warm-up on something they built — coursework, internship or side project (10m)
+2. Practical coding: string/collection manipulation, correctness over cleverness (20m)
+3. Basic API and data modelling discussion (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Walk me through a project you built. What part took the longest, and why?"
+- "You call an API and get a 500. Walk me through everything you'd check, in order."
+- "Write a function that takes a list of orders and returns each customer's total. Now the list is too big to fit in memory — what changes?"
+- "What is the difference between a 401 and a 403, and when have you seen each?"
+- "You need to store users and the posts they write. Sketch the tables. How do you fetch one user's posts?"
+- "Tell me about a bug that took you more than a day. How did you finally find it?"
+- "What does your code review feedback usually look like — what do people ask you to change?"
+
+## Signals
+- Reads the problem carefully and asks a clarifying question before coding.
+- Debugs by narrowing the search space (logs, inputs, a smaller repro) rather than guessing and re-running.
+- Says 'I don't know' cleanly, then reasons from what they do know.
+- Talks about their own contribution specifically, not the team's project in the abstract.
+
+## Pitfalls
+- Jumps straight to code before understanding the requirement, then rewrites twice.
+- Cannot explain code they wrote — a sign it came from somewhere they didn't read.
+- Treats every error as a mystery instead of reading the actual message.
+- Memorized definitions (ACID, REST) with no example of ever using them.

--- a/skills/generic-backend-engineer-mid.md
+++ b/skills/generic-backend-engineer-mid.md
@@ -1,0 +1,49 @@
+---
+id: generic-backend-engineer-mid
+company: generic
+role: backend-engineer
+level: mid
+competency:
+  - api-design
+  - data-modeling
+  - testing
+  - debugging
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Backend Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a service they own day to day (12m)
+2. Design a small system end to end — API surface, storage, failure handling (18m)
+3. Debugging and operational judgment (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe a service you own. What does it do, who calls it, and what happens when it's down?"
+- "Design a URL shortener. Now tell me what breaks when one link goes viral."
+- "You need to add a required column to a table with 50 million rows, live. What's the plan?"
+- "A background job silently stopped processing three days ago and nobody noticed. What went wrong beyond the job itself?"
+- "How do you decide what to unit test versus integration test? Where have you gotten that balance wrong?"
+- "Two services need the same data. When do you duplicate it, and when do you call across?"
+- "Walk me through the last time you had to make an API change that would break a consumer."
+
+## Signals
+- Designs the failure path, not just the happy path — timeouts, retries, what the caller sees.
+- Chooses boring, appropriate technology and can say why the exotic option is unnecessary here.
+- Has opinions about testing formed by being burned, with a specific story attached.
+- Distinguishes what they built from what they inherited.
+
+## Pitfalls
+- Adds a cache or a queue as a reflex, without a bottleneck to point at.
+- Cannot describe how their service fails, only how it works.
+- Describes 'we have tests' with no sense of what those tests actually protect.
+- Skips the migration/rollout question — designs a finished state with no path to it.

--- a/skills/generic-backend-engineer-staff.md
+++ b/skills/generic-backend-engineer-staff.md
@@ -1,0 +1,50 @@
+---
+id: generic-backend-engineer-staff
+company: generic
+role: backend-engineer
+level: staff
+competency:
+  - system-design
+  - technical-leadership
+  - cross-team-influence
+  - operational-maturity
+  - judgment
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Staff Backend Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Scope and impact of the largest thing they've driven (15m)
+2. Ambiguous system design with organizational constraints (20m)
+3. Influence, disagreement and technical strategy (15m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about the largest technical decision you've owned. Who disagreed, and how did that resolve?"
+- "Design a platform capability three teams will build on. How do you keep it from becoming a bottleneck — organizationally, not just technically?"
+- "Describe a migration you led that took more than two quarters. What did you get wrong at the start?"
+- "When have you decided NOT to fix something you knew was broken? How did you make that call defensible?"
+- "How do you tell the difference between technical debt worth paying down and technical debt worth living with?"
+- "Tell me about a time you changed the direction of a project that was already underway."
+- "What does your org do today that will not survive 5x growth, and how would you sequence fixing it?"
+- "How have you grown other engineers — specifically, not as a philosophy?"
+
+## Signals
+- Frames technical choices in terms of what the business or other teams can then do.
+- Talks about sequencing and reversibility: what to decide now, what to defer, what can be undone.
+- Owns a specific mistake at scale and what changed structurally afterward.
+- Influences without authority — persuasion, prototypes, and written arguments rather than escalation.
+
+## Pitfalls
+- Describes leadership as a title rather than as decisions with names and dates attached.
+- Designs for elegance where the real constraint is migration cost or team capacity.
+- Cannot name a trade-off they'd defend against a smart engineer who disagrees.
+- Every story is a success story — no evidence of updating on being wrong.

--- a/skills/generic-data-engineer-mid.md
+++ b/skills/generic-data-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-data-engineer-mid
+company: generic
+role: data-engineer
+level: mid
+competency:
+  - data-modeling
+  - pipelines
+  - sql
+  - data-quality
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Data Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a pipeline they own (12m)
+2. Design a pipeline end to end — ingestion, transformation, serving (18m)
+3. Data quality, backfills and debugging (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe a pipeline you own. What happens when it fails at 3am?"
+- "Design a daily pipeline turning raw event logs into a table analysts query. Where does it break first?"
+- "A dashboard number looks wrong. How do you trace it back to the source?"
+- "How do you handle late-arriving data without corrupting yesterday's numbers?"
+- "Write the query: for each user, their first and most recent purchase, plus lifetime total."
+- "When do you choose ELT over ETL — and when has that been the wrong call?"
+- "How do you make a backfill safe and repeatable?"
+
+## Signals
+- Designs for idempotency and re-runs, because pipelines always get re-run.
+- Thinks about the consumer of the data, not just the mechanics of moving it.
+- Has real data-quality checks with owners, not just a monitoring dashboard.
+- Comfortable with SQL beyond joins — window functions, aggregation, and why a query is slow.
+
+## Pitfalls
+- Pipelines that cannot be re-run without duplicating or losing rows.
+- Treats schema changes upstream as someone else's problem.
+- No distinction between a pipeline that failed and one that quietly produced wrong data.
+- Chooses tooling by popularity with no fit to the data volume at hand.

--- a/skills/generic-data-engineer-senior.md
+++ b/skills/generic-data-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-data-engineer-senior
+company: generic
+role: data-engineer
+level: senior
+competency:
+  - data-architecture
+  - pipelines
+  - reliability
+  - cost-efficiency
+  - stakeholder-management
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Data Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a platform or warehouse they've shaped (14m)
+2. Architecture for a multi-source, multi-consumer data platform (20m)
+3. Reliability, cost and organizational trade-offs (11m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe the data platform you've most shaped. What did you inherit and what did you change?"
+- "Design a system serving both analytics and a production feature from the same event stream."
+- "How do you decide between streaming and batch — and where have you seen streaming chosen wrongly?"
+- "Warehouse spend doubled in a quarter. How do you find out why and what do you do about it?"
+- "How do you handle a breaking schema change from a team that doesn't report to you?"
+- "What does data ownership look like on your team in practice, not on paper?"
+- "Tell me about a data incident with real business consequences. What changed afterward?"
+- "How do you keep a semantic layer from drifting away from what the business means?"
+
+## Signals
+- Treats data contracts and ownership as organizational design, not just tooling.
+- Reasons about cost per query and storage tiering as an engineering constraint.
+- Distinguishes correctness incidents from availability incidents and treats them differently.
+- Has moved a platform without a flag day — dual-writes, shadow reads, staged cutover.
+
+## Pitfalls
+- Builds a beautiful platform nobody adopts, with no account of why.
+- Ignores cost entirely, or optimizes it at the expense of trust in the data.
+- Cannot describe how upstream teams are held to a contract.
+- Every answer is a tool name rather than a property they needed.

--- a/skills/generic-data-scientist-mid.md
+++ b/skills/generic-data-scientist-mid.md
@@ -1,0 +1,49 @@
+---
+id: generic-data-scientist-mid
+company: generic
+role: data-scientist
+level: mid
+competency:
+  - statistics
+  - experimentation
+  - modeling
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Data Scientist
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on an analysis or model that changed a decision (12m)
+2. Experiment design and statistical reasoning (18m)
+3. Modeling and practical trade-offs (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about an analysis that changed what your team did. How did you know it was right?"
+- "Design an A/B test for a checkout change. What's your metric, and how long do you run it?"
+- "The test is positive on the primary metric and negative on retention. What now?"
+- "How do you handle a stakeholder who wants the result before the experiment is finished?"
+- "You have a model at 95% accuracy on an imbalanced dataset. Why might that be worthless?"
+- "How do you decide whether a problem needs a model at all?"
+- "Walk me through how you'd investigate a sudden drop in a key metric."
+- "What's a result you were confident in that turned out to be wrong?"
+
+## Signals
+- Starts from the decision the analysis is meant to inform, not the technique.
+- Reasons about power, variance and duration before running anything.
+- Interrogates data quality and selection effects before interpreting.
+- Explains uncertainty to non-technical people without either false precision or hedging into uselessness.
+
+## Pitfalls
+- Reaches for a complex model where a well-chosen cut of the data answers the question.
+- Reports point estimates with no interval and no sense of noise.
+- Peeks at running experiments and stops on significance.
+- Cannot say what would have changed their mind.

--- a/skills/generic-devops-engineer-mid.md
+++ b/skills/generic-devops-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-devops-engineer-mid
+company: generic
+role: devops-engineer
+level: mid
+competency:
+  - ci-cd
+  - infrastructure-as-code
+  - observability
+  - automation
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level DevOps Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a pipeline or platform they maintain (12m)
+2. Design a deployment path for a service, dev to production (18m)
+3. Incident, observability and toil questions (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe the deployment pipeline you maintain. What's the slowest and least trusted part?"
+- "Design the path a commit takes to production for a team of ten. Where are the gates?"
+- "A deploy went out and errors spiked. What happens next, and how much of it is automatic?"
+- "How do you manage secrets across environments?"
+- "What's the most repetitive thing your team does, and what would it take to automate it away?"
+- "How do you know a service is healthy beyond 'the process is running'?"
+- "How do you handle infrastructure drift between what's in code and what's actually deployed?"
+
+## Signals
+- Optimizes for fast, safe rollback rather than preventing every bad deploy.
+- Treats infrastructure as code seriously, including review and testing of that code.
+- Measures the pipeline itself — lead time, failure rate, restore time.
+- Reduces toil deliberately and can name what they removed.
+
+## Pitfalls
+- Manual steps in the critical path documented in a wiki nobody reads.
+- Alerts on causes rather than symptoms, producing noise people ignore.
+- Snowflake environments where staging doesn't predict production.
+- Secrets in CI variables with no rotation story.

--- a/skills/generic-engineering-manager-senior.md
+++ b/skills/generic-engineering-manager-senior.md
@@ -1,0 +1,51 @@
+---
+id: generic-engineering-manager-senior
+company: generic
+role: engineering-manager
+level: senior
+competency:
+  - people-management
+  - delivery
+  - technical-judgment
+  - hiring
+  - stakeholder-management
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Engineering Manager
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Team and scope deep-dive — what they inherited and what changed (15m)
+2. Delivery and prioritization scenario (18m)
+3. People scenarios: performance, growth, conflict (17m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe the team you manage. What was true when you started that isn't now?"
+- "You're committed to a date and it's clearly not going to happen. Walk me through the next week."
+- "Tell me about someone you managed who wasn't performing. What did you actually do?"
+- "How do you decide what your team works on when three stakeholders each want something different?"
+- "How involved are you technically, and where has that line been wrong?"
+- "Tell me about someone you helped grow into a bigger role. What did you do specifically?"
+- "Two senior engineers on your team disagree strongly on architecture and it's blocking work. What now?"
+- "How do you know your team is healthy? What would you notice first if it weren't?"
+- "How do you handle attrition you didn't see coming?"
+
+## Signals
+- Talks about individuals with specificity and respect, including hard conversations.
+- Escalates schedule risk early with options rather than late with apologies.
+- Retains enough technical judgment to evaluate a plan without doing the work.
+- Distinguishes what they did from what the team did, in both directions.
+
+## Pitfalls
+- Performance stories that end in a departure with no attempt at coaching described.
+- Protects the team from context rather than sharing it.
+- Prioritizes by loudest stakeholder and calls it responsiveness.
+- Cannot name a management mistake or what it cost.

--- a/skills/generic-frontend-engineer-junior.md
+++ b/skills/generic-frontend-engineer-junior.md
@@ -1,0 +1,48 @@
+---
+id: generic-frontend-engineer-junior
+company: generic
+role: frontend-engineer
+level: junior
+competency:
+  - fundamentals
+  - ui-implementation
+  - debugging
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Junior Frontend Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Walk-through of something they built and can show (10m)
+2. Practical component building — state, events, rendering (20m)
+3. Browser fundamentals and debugging (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Show me something you built. What part are you proudest of, and what would you redo?"
+- "Build a search box that filters a list as you type. Now the list has 10,000 items — what changes?"
+- "What actually happens between typing a URL and seeing the page?"
+- "A button works on your machine but not for a user on Safari. How do you start?"
+- "What is the difference between state and props — and when have you had state in the wrong place?"
+- "How do you make sure a form is usable with a keyboard only?"
+- "Your page feels slow. What are the first three things you look at?"
+
+## Signals
+- Uses browser devtools as a first instinct — network tab, element inspector, console.
+- Thinks about the user in concrete terms: loading, empty, error, and slow-connection states.
+- Knows what the framework is doing on their behalf, at least roughly.
+- Mentions accessibility or responsiveness unprompted, even briefly.
+
+## Pitfalls
+- Only knows one framework's idioms with no sense of the underlying DOM.
+- Ignores loading and error states entirely — builds only the success screen.
+- Cannot explain why a re-render happened.
+- Styles by trial and error without reading what the layout is actually doing.

--- a/skills/generic-frontend-engineer-senior.md
+++ b/skills/generic-frontend-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-frontend-engineer-senior
+company: generic
+role: frontend-engineer
+level: senior
+competency:
+  - architecture
+  - performance
+  - accessibility
+  - state-management
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Frontend Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a front-end system they've owned (12m)
+2. Architecture and state design for a non-trivial UI (18m)
+3. Performance, accessibility and quality trade-offs (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe the most complex UI you've owned. What made it complex — the domain, the data, or the team?"
+- "Design the front end for a dashboard with a dozen live-updating widgets. Where does the state live and why?"
+- "Your app's largest contentful paint regressed 40% after a release. Walk me through the investigation."
+- "How do you decide between server-side rendering, static generation, and client rendering for a given page?"
+- "What's your approach to a design system that three teams contribute to?"
+- "Tell me about an accessibility problem you found late. What would have caught it earlier?"
+- "When is a global store the wrong answer?"
+- "How do you keep a large front-end codebase from rotting — specifically?"
+
+## Signals
+- Reasons about rendering and data-fetching boundaries deliberately, not by framework default.
+- Has real performance numbers and knows which metric matters for which user complaint.
+- Treats accessibility as a build-time concern rather than an audit at the end.
+- Can explain a front-end decision to a backend engineer or a designer without jargon.
+
+## Pitfalls
+- Reaches for a state library before establishing what state actually needs sharing.
+- Optimizes bundle size while ignoring what the user actually waits on.
+- Describes 'clean architecture' with no example of a decision it made easier.
+- Blames designers or the backend for every constraint, with no collaboration story.

--- a/skills/generic-full-stack-engineer-mid.md
+++ b/skills/generic-full-stack-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-full-stack-engineer-mid
+company: generic
+role: full-stack-engineer
+level: mid
+competency:
+  - end-to-end-delivery
+  - api-design
+  - ui-implementation
+  - pragmatism
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Full-stack Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a feature they built across the stack (12m)
+2. Design a feature end to end — data, API, UI (18m)
+3. Trade-offs and debugging across boundaries (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Walk me through a feature you built from database to pixels. Where did the tricky part turn out to be?"
+- "Design commenting with replies for an existing app. Schema, endpoints, and how the UI stays fast."
+- "Something is slow. How do you work out whether it's the query, the API, the network, or the render?"
+- "Where do you put validation — client, server, or database? Defend the duplication."
+- "You need to ship a feature this week but doing it properly takes three. What do you actually do?"
+- "How do you keep front-end and back-end types from drifting apart?"
+- "Tell me about a bug that lived at a boundary between two systems."
+
+## Signals
+- Comfortable being specific on both sides rather than strong on one and vague on the other.
+- Instruments and measures before deciding which layer is at fault.
+- Makes an explicit, time-boxed shortcut and names the debt it creates.
+- Thinks about the contract between layers as a real artifact.
+
+## Pitfalls
+- Claims full-stack but flattens into one side under follow-up questions.
+- Validates only on the client, or only on the server, without a reason.
+- Blames 'the API' or 'the frontend' for problems at the seam.
+- No sense of what a feature costs to maintain after it ships.

--- a/skills/generic-full-stack-engineer-senior.md
+++ b/skills/generic-full-stack-engineer-senior.md
@@ -1,0 +1,48 @@
+---
+id: generic-full-stack-engineer-senior
+company: generic
+role: full-stack-engineer
+level: senior
+competency:
+  - system-design
+  - end-to-end-delivery
+  - technical-leadership
+  - operational-maturity
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Full-stack Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Ownership deep-dive on a product surface they carried (12m)
+2. System design spanning storage, service and client (20m)
+3. Delivery judgment, quality and mentoring (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe a product area you owned end to end. What did you decide that someone else would have decided differently?"
+- "Design a collaborative document editor — start simple, then tell me where it gets hard."
+- "How do you roll out a change that touches schema, API and client at once, without downtime?"
+- "What does 'done' mean for a feature on your team — and who decided that?"
+- "Tell me about a time the right technical answer was the wrong product answer."
+- "How do you handle a stack where one layer is far weaker than the others?"
+- "Where do you draw the line between a shared library and duplicated code?"
+
+## Signals
+- Sequences a cross-layer change safely: expand, migrate, contract — not a big-bang deploy.
+- Connects technical choices to product consequences and user-visible behavior.
+- Has raised the floor for a team, not just shipped their own work.
+- Knows which layer they're weakest in and says so without hedging.
+
+## Pitfalls
+- Designs the end state with no rollout story.
+- Optimizes their own velocity at the cost of everyone else's.
+- Treats product constraints as noise interfering with engineering.
+- Generalizes into a shared abstraction after two examples and can't say why.

--- a/skills/generic-ios-engineer-senior.md
+++ b/skills/generic-ios-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-ios-engineer-senior
+company: generic
+role: ios-engineer
+level: senior
+competency:
+  - swift
+  - apple-platform
+  - architecture
+  - performance
+  - app-quality
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior iOS Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on an iOS codebase they've owned (12m)
+2. Architecture and concurrency design for a feature (18m)
+3. Performance, memory and shipping practice (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe an iOS app you owned. What was the state of it when you arrived, and when you left?"
+- "Design an image-heavy feed that scrolls smoothly on a five-year-old device."
+- "How do you reason about concurrency in Swift today — where has it bitten you?"
+- "When would you choose SwiftUI, UIKit, or both in one screen?"
+- "Memory is climbing while the user scrolls. How do you find out why?"
+- "How do you structure a module so it can be tested without a device?"
+- "Tell me about an App Store rejection or a privacy requirement that changed your design."
+- "How do you support two OS versions back without freezing your architecture?"
+
+## Signals
+- Reasons about the main thread as a scarce resource with a frame budget.
+- Uses Instruments or equivalent tooling as a first response rather than a last resort.
+- Understands Apple's constraints — review, privacy, deprecation — as design inputs.
+- Can justify an architecture in terms of testability and team size, not fashion.
+
+## Pitfalls
+- Cargo-cults an architecture pattern with no account of what it cost.
+- Treats retain cycles and memory as an occasional mystery rather than something to measure.
+- Only knows the newest APIs, with no plan for supported older versions.
+- Ignores accessibility and Dynamic Type on a consumer app.

--- a/skills/generic-machine-learning-engineer-mid.md
+++ b/skills/generic-machine-learning-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-machine-learning-engineer-mid
+company: generic
+role: machine-learning-engineer
+level: mid
+competency:
+  - ml-fundamentals
+  - data-pipelines
+  - evaluation
+  - productionization
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Machine Learning Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a model they took to production (12m)
+2. Design an ML system — data, training, serving, monitoring (18m)
+3. Evaluation and debugging a misbehaving model (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about a model you put in production. What was different from the notebook?"
+- "Design a recommendation system for a mid-size catalog. Start with what you'd ship first."
+- "Your offline metrics improved but the online metric didn't move. What are the candidate explanations?"
+- "How do you detect that a model in production has gone stale?"
+- "What's your validation split strategy when the data is a time series?"
+- "How do you choose a baseline, and when have you failed to beat one?"
+- "Where does feature computation live at training time versus serving time, and how do you keep them consistent?"
+
+## Signals
+- Ships a simple baseline first and treats model complexity as a cost.
+- Understands training/serving skew as a systems problem, not a modeling detail.
+- Chooses metrics tied to the product outcome, and knows their failure modes.
+- Monitors inputs, not just outputs — drift shows up in features first.
+
+## Pitfalls
+- Reports accuracy with no baseline and no class balance.
+- Leaks future information into training and cannot spot it when walked through.
+- Treats deployment as someone else's job.
+- Chases model architecture where the data is the bottleneck.

--- a/skills/generic-machine-learning-engineer-senior.md
+++ b/skills/generic-machine-learning-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-machine-learning-engineer-senior
+company: generic
+role: machine-learning-engineer
+level: senior
+competency:
+  - ml-systems
+  - experimentation
+  - productionization
+  - technical-leadership
+  - cost-efficiency
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Machine Learning Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on an ML system they own end to end (14m)
+2. Architecture for training, serving and iteration at scale (20m)
+3. Judgment: when ML is and isn't the answer (11m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe an ML system you own. How does a model get from an idea to serving traffic?"
+- "Design the retraining and rollout path for a model where a bad version costs real money."
+- "How do you evaluate a model whose ground truth arrives weeks later?"
+- "When have you argued against using ML for something?"
+- "Serving costs are dominating the model's value. What levers do you pull, in what order?"
+- "How do you keep a team of ML engineers from producing five incompatible pipelines?"
+- "Tell me about a model failure in production. What did the postmortem change structurally?"
+- "How do you handle feedback loops where the model influences its own future training data?"
+
+## Signals
+- Designs the iteration loop — how fast can a hypothesis become a measured result.
+- Treats rollback, shadow evaluation and guardrail metrics as required infrastructure.
+- Reasons about unit economics of inference and where quality is worth paying for.
+- Aware of feedback loops, degenerate optimization and the ways metrics get gamed.
+
+## Pitfalls
+- Optimizes benchmark numbers with no line to a business or user outcome.
+- No plan for rolling back a bad model beyond redeploying the old one manually.
+- Cannot explain how their system would be debugged by someone else.
+- Ignores the label pipeline, which is usually where the real problem lives.

--- a/skills/generic-mobile-engineer-mid.md
+++ b/skills/generic-mobile-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-mobile-engineer-mid
+company: generic
+role: mobile-engineer
+level: mid
+competency:
+  - mobile-platform
+  - ui-implementation
+  - offline-and-state
+  - performance
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Mobile Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on an app they shipped to a store (12m)
+2. Feature design under mobile constraints — offline, battery, lifecycle (18m)
+3. Debugging, crashes and release practice (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about an app you shipped. What did the store review or launch teach you?"
+- "Design an inbox that works offline and syncs when connectivity returns. What happens on conflict?"
+- "Your crash rate jumped after a release. Walk me through the first hour."
+- "How do you handle a screen whose data comes from three endpoints with different latencies?"
+- "What does the OS do to your app in the background, and how have you had to work around it?"
+- "How do you test something that only reproduces on a real device?"
+- "You can't hotfix — the release is in review. How does that change how you ship?"
+
+## Signals
+- Designs for interruption: backgrounding, process death, restoration, flaky networks.
+- Treats app size, battery and cold-start as real budgets with numbers.
+- Has an actual crash-triage workflow, including how they get symbolicated stacks.
+- Understands release trains and staged rollouts as risk management.
+
+## Pitfalls
+- Assumes connectivity and treats offline as an error state to show.
+- Ignores platform lifecycle, then can't explain a class of state-loss bugs.
+- Tests exclusively on the simulator and the newest flagship device.
+- No plan for a bad release beyond 'ship a fix'.

--- a/skills/generic-platform-engineer-senior.md
+++ b/skills/generic-platform-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-platform-engineer-senior
+company: generic
+role: platform-engineer
+level: senior
+competency:
+  - platform-design
+  - developer-experience
+  - abstraction-judgment
+  - operational-maturity
+  - cross-team-influence
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Platform Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a platform capability they built and shipped internally (14m)
+2. Design a self-service capability for other engineering teams (20m)
+3. Adoption, migration and support trade-offs (11m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe a platform capability you built. How many teams use it, and how did the first one get on board?"
+- "Design self-service environments for twenty teams. What do you standardize and what do you leave open?"
+- "How do you migrate every team off an old internal tool without stopping their work?"
+- "When does an internal abstraction become a liability?"
+- "How do you handle a team that needs an exception to your platform's constraints?"
+- "What does support look like for something you own but everyone depends on?"
+- "How do you measure whether a platform is actually helping?"
+- "Tell me about a platform decision you reversed."
+
+## Signals
+- Designs escape hatches — the abstraction can be stepped around without leaving the platform.
+- Measures adoption and developer experience rather than assuming value.
+- Migrates with dual-running and deprecation timelines rather than mandates.
+- Treats internal users as customers, including their right to say no.
+
+## Pitfalls
+- Builds the platform they'd want rather than the one teams need next quarter.
+- Mandates adoption without making the paved path genuinely easier.
+- Abstractions that leak badly under load, with no way to see through them.
+- No deprecation strategy, so every old version lives forever.

--- a/skills/generic-product-manager-mid.md
+++ b/skills/generic-product-manager-mid.md
@@ -1,0 +1,50 @@
+---
+id: generic-product-manager-mid
+company: generic
+role: product-manager
+level: mid
+competency:
+  - product-sense
+  - prioritization
+  - execution
+  - data-literacy
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Product Manager
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Product deep-dive on something they shipped (14m)
+2. Product sense and prioritization exercise (18m)
+3. Execution, metrics and working with engineering (13m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about a product you shipped. What did you cut, and what did that cost?"
+- "Users say onboarding is confusing. How do you find out what's actually wrong?"
+- "You have four roadmap items and capacity for two. Walk me through the decision."
+- "How do you know whether a feature you launched worked?"
+- "Engineering says the estimate is three months and you expected three weeks. What happens next?"
+- "Pick a product you use that frustrates you. What would you change, and what would break?"
+- "How do you write a spec that engineers actually find useful?"
+- "Tell me about a decision you made that the data later showed was wrong."
+
+## Signals
+- Starts from the user problem and the evidence for it, not the feature.
+- Makes prioritization explicit — what they're saying no to, and why.
+- Defines success before launch and follows through on measuring it.
+- Works with engineering on constraints rather than negotiating estimates.
+
+## Pitfalls
+- Feature lists with no problem statement behind them.
+- Metrics chosen after the fact to make a launch look good.
+- Treats engineering estimates as an opening bid.
+- Cannot describe a trade-off they personally made and defended.

--- a/skills/generic-qa-engineer-mid.md
+++ b/skills/generic-qa-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-qa-engineer-mid
+company: generic
+role: qa-engineer
+level: mid
+competency:
+  - test-strategy
+  - automation
+  - exploratory-testing
+  - quality-advocacy
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level QA / Test Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on how they test a product they know well (12m)
+2. Design a test strategy for a feature end to end (18m)
+3. Automation, flakiness and release judgment (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Take a product you know. How would you test a change to its checkout flow?"
+- "Design the test strategy for a new payments feature. What's automated, what isn't, and why?"
+- "Your suite has 30 flaky tests. What do you do this week, and what do you do about the cause?"
+- "How do you decide a release is ready to go when a few known bugs remain?"
+- "What's the most interesting bug you've found, and how did you find it?"
+- "How do you test something that depends on a third-party service you don't control?"
+- "How do you get developers to care about the tests you write?"
+
+## Signals
+- Thinks in terms of risk coverage rather than test count.
+- Explores actively — hypothesis-driven, not just following a script.
+- Treats flakiness as a defect in the test system, with a real fix.
+- Advocates for quality by making problems visible early, not by gatekeeping at the end.
+
+## Pitfalls
+- Automates everything at the UI layer, producing a slow and brittle suite.
+- Reports bugs without a reproduction or an assessment of impact.
+- Sees quality as their exclusive responsibility rather than the team's.
+- Cannot say what their tests would fail to catch.

--- a/skills/generic-security-engineer-senior.md
+++ b/skills/generic-security-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-security-engineer-senior
+company: generic
+role: security-engineer
+level: senior
+competency:
+  - threat-modeling
+  - secure-design
+  - incident-response
+  - risk-prioritization
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Security Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on a security problem they owned (14m)
+2. Threat-model a system and design mitigations (20m)
+3. Risk prioritization and working with product teams (11m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about a security issue you found or fixed. How did you decide how urgent it was?"
+- "Threat-model a file-sharing feature: who are the attackers, and what do they get?"
+- "How do you prioritize a backlog of vulnerabilities that all look scary in the scanner?"
+- "A team wants to ship something you think is risky, and the deadline is real. What do you do?"
+- "Walk me through how you'd handle a credential leaked in a public repository."
+- "How do you design authorization for a system with organizations, teams and roles?"
+- "What's a security control your team adopted that turned out not to be worth it?"
+- "How do you make secure defaults the easy path for engineers?"
+
+## Signals
+- Reasons about risk in terms of likelihood and blast radius, not severity labels alone.
+- Designs controls engineers will actually adopt rather than ones that get bypassed.
+- Distinguishes theoretical vulnerabilities from exploitable ones in this specific system.
+- Communicates risk to non-security people without either alarmism or jargon.
+
+## Pitfalls
+- Blocks work without offering a viable path forward.
+- Treats compliance checkboxes as equivalent to security outcomes.
+- Fixates on exotic attacks while basics (authz, secrets, patching) go unaddressed.
+- No incident story — only prevention in the abstract.

--- a/skills/generic-site-reliability-engineer-senior.md
+++ b/skills/generic-site-reliability-engineer-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-site-reliability-engineer-senior
+company: generic
+role: site-reliability-engineer
+level: senior
+competency:
+  - reliability-engineering
+  - incident-response
+  - observability
+  - capacity-planning
+  - systems-debugging
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Site Reliability Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on the hardest incident they've run (14m)
+2. Reliability design for a critical service — SLOs, failure domains, degradation (20m)
+3. Capacity, cost and organizational reliability practice (11m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Walk me through the worst incident you've been on point for. What did you know and when?"
+- "Define SLOs for a checkout service. What do you do when the error budget is spent?"
+- "Design graceful degradation for a service whose main dependency is down."
+- "Latency is fine at p50 and terrible at p99. Where do you look?"
+- "How do you plan capacity for an event you know is coming — and one you don't?"
+- "What makes a postmortem actually change something?"
+- "How do you push back on a team that keeps shipping unreliable services?"
+- "Tell me about a monitoring gap you only found because of an outage."
+
+## Signals
+- Separates mitigation from root cause and prioritizes restoring service.
+- Uses error budgets as a shared language with product, not as a cudgel.
+- Debugs distributed systems by narrowing failure domains methodically.
+- Blameless in practice — talks about systems and defaults, not individuals.
+
+## Pitfalls
+- Heroics as a reliability strategy, with pride rather than concern.
+- Every incident's action item is 'add more monitoring'.
+- Cannot describe how a change is rolled out or rolled back.
+- Treats reliability as an SRE-only responsibility.

--- a/skills/generic-software-engineer-intern.md
+++ b/skills/generic-software-engineer-intern.md
@@ -1,0 +1,48 @@
+---
+id: generic-software-engineer-intern
+company: generic
+role: software-engineer
+level: intern
+competency:
+  - fundamentals
+  - learning-agility
+  - communication
+  - curiosity
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Software Engineering Intern
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Introductions and a project or coursework walk-through (10m)
+2. Guided coding problem — thinking out loud matters more than finishing (20m)
+3. Learning and collaboration questions (8m)
+4. Candidate questions + wrap (7m)
+
+## Question bank
+- "Tell me about a project — class, personal or hackathon — you enjoyed working on. What did you actually write?"
+- "Given a list of numbers, find the two that sum to a target. Start with the simplest thing that works."
+- "When you get stuck on something for an hour, what do you do?"
+- "What's something technical you learned recently, and how did you learn it?"
+- "How do you test that code you just wrote is right, without a test framework?"
+- "Describe working on something with other people. What was hard about it?"
+- "What do you want to learn in this internship?"
+
+## Signals
+- Thinks out loud, so their reasoning is visible even when the answer isn't there yet.
+- Takes a hint and runs with it instead of waiting to be given the answer.
+- Checks their own work with a concrete example before declaring it done.
+- Curious about why things are the way they are, not just how to make them pass.
+
+## Pitfalls
+- Silence while stuck — no signal for the interviewer to work with.
+- Recites a memorized solution without being able to explain a step.
+- Cannot name anything specific they did on a group project.
+- Treats not knowing something as a failure rather than a starting point.

--- a/skills/generic-software-engineer-mid.md
+++ b/skills/generic-software-engineer-mid.md
@@ -1,0 +1,48 @@
+---
+id: generic-software-engineer-mid
+company: generic
+role: software-engineer
+level: mid
+competency:
+  - problem-solving
+  - code-quality
+  - testing
+  - collaboration
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Mid-level Software Engineer
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Project deep-dive on something they shipped (12m)
+2. Coding: a problem with a naive answer and a better one (20m)
+3. Design and code-quality discussion (8m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Tell me about something you shipped end to end. What did you own versus review?"
+- "Given a stream of events, return the top K most frequent in the last hour. Talk me through your approach before coding."
+- "How would you refactor a 500-line function you have to change next week?"
+- "Describe a time your code caused a production problem. What happened next?"
+- "How do you decide when a piece of code needs a test?"
+- "You disagree with a code review comment from a more senior engineer. What do you do?"
+- "What's a piece of feedback that changed how you write code?"
+
+## Signals
+- States the approach and its complexity before writing code, and revises it out loud.
+- Handles the edge cases they identified rather than the ones they were prompted for.
+- Talks about readability and the next person to touch the code.
+- Owns a production mistake without either minimizing it or over-apologizing.
+
+## Pitfalls
+- Optimizes prematurely, or cannot say what the bottleneck would be.
+- Writes code that works for the example and breaks on the empty case.
+- Treats code review as approval rather than as a conversation.
+- Cannot describe anything they'd do differently in a project they just called finished.

--- a/skills/generic-technical-program-manager-senior.md
+++ b/skills/generic-technical-program-manager-senior.md
@@ -1,0 +1,50 @@
+---
+id: generic-technical-program-manager-senior
+company: generic
+role: technical-program-manager
+level: senior
+competency:
+  - program-execution
+  - cross-team-coordination
+  - risk-management
+  - technical-judgment
+  - communication
+version: 1
+source_runs: 0
+confidence: 0.5
+last_verified: 2026-08-26
+status: promoted
+---
+
+# Generic — Senior Technical Program Manager
+
+> Company-agnostic playbook: matched as a fallback when no company-specific
+> pack exists. Hand-curated (not distilled from runs), hence `source_runs: 0` and moderate confidence.
+
+## Round structure
+1. Deep-dive on the largest program they've driven (15m)
+2. Planning and risk scenario across multiple teams (20m)
+3. Communication, escalation and stakeholder judgment (10m)
+4. Candidate questions + wrap (5m)
+
+## Question bank
+- "Describe the largest program you've run. How many teams, and what was the hardest dependency?"
+- "Two teams' deliverables are coupled and one just slipped a month. What do you do first?"
+- "How do you build a plan when half the work is genuinely unknown?"
+- "How do you tell the difference between a risk worth escalating and one worth watching?"
+- "A team keeps reporting green and then slipping. How do you handle it?"
+- "How technical do you get — and where does that stop being useful?"
+- "What does a status update you write actually contain?"
+- "Tell me about a program that failed or was cancelled. What was your read on it at the time?"
+
+## Signals
+- Tracks dependencies and critical path concretely, with owners and dates.
+- Escalates with a recommendation, not just a problem.
+- Understands the technical work well enough to challenge an estimate respectfully.
+- Writes updates that let a busy reader act without a meeting.
+
+## Pitfalls
+- Confuses activity tracking with risk management.
+- Surfaces problems only when they've become unrecoverable.
+- No independent technical read — relays what teams say without judgment.
+- Process for its own sake, with no story of removing any.


### PR DESCRIPTION
Week-2 growth item from the launch plan, and the supply side of #38.

## Why
The library had **three** usable packs, all engineering ICs (backend-senior, frontend-mid, software-engineer-junior). Any JD outside that narrow band retrieved nothing, so the planner worked from the CV and JD alone — the packs were a documented feature that mostly didn't fire.

## What
26 new `company: generic` packs (matched as fallbacks for any company), taking the library to **30**:

| Area | Packs |
|---|---|
| Core engineering | backend junior/mid/staff · frontend junior/senior · software-engineer intern/mid · full-stack mid/senior |
| Mobile | mobile mid · iOS senior · Android mid |
| Data | data-engineer mid/senior · data-scientist mid |
| ML / AI | ML engineer mid/senior · **AI engineer senior (LLM applications)** |
| Infra | devops mid · SRE senior · platform senior |
| Quality & security | QA mid · security senior |
| Leadership & product | engineering-manager senior · product-manager mid · TPM senior |

Each follows the existing format: round structure, 7–9 questions, signals, pitfalls.

## Provenance, stated honestly
All are **hand-curated, not distilled from runs** — `source_runs: 0`, `confidence: 0.5`, matching the existing generic packs, with the provenance line in every file. Questions are recollection-based and company-agnostic by construction, so no company's real interview content is reproduced. That is the content policy in `skills/README.md`, and these are meant to be the model contributors copy.

## Slugs were verified, not assumed
Retrieval was run against fifteen realistic JD titles rather than trusting the slug to match. That is how `full-stack-engineer` beat `fullstack-engineer`: the matcher compares tokens, so `{fullstack, engineer}` is not a subset of `{senior, full, stack, engineer}` and the pack would never have fired on "Senior Full Stack Engineer".

The same check surfaced **pre-existing** misses that slug choice cannot fix — `"Front End Engineer"` doesn't match `frontend-engineer`, and `"Software Engineering Intern"` doesn't match `software-engineer`, because `engineering ≠ engineer`. That is a matcher fix and is coming as its own PR rather than being buried in a content change.

## Verification
- `deepinterview skills lint` — **30 packs, 0 errors**. The single warning is pre-existing on the fictional `example-corp-backend-senior` sample (`id` predates the `{company}-{role}-{level}` convention); fixing it means touching a test assertion and the SCHEMA example, so it stays out of this PR.
- Pack index in `skills/README.md` regenerated with `skilllib.gen_index`.
- `pytest` — 216 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)