### PR TITLE
fix(skills): match the way job titles are actually written

### DIFF
--- a/apps/agent/src/deepinterview_agent/skilllib/store.py
+++ b/apps/agent/src/deepinterview_agent/skilllib/store.py
@@ -153,11 +153,54 @@ _STATUS_RANK = {"promoted": 0, "review": 1, "draft": 2}
 _CONFIDENCE_HALF_LIFE_DAYS = 180.0
 
 
+# Spellings that mean the same job but tokenize differently. Both sides of the
+# match run through ``_role_tokens``, so every entry works in either direction:
+# a title written "Front End Engineer" finds a ``frontend-engineer`` pack, and a
+# hypothetical ``front-end-engineer`` pack is found by "Frontend Engineer".
+#
+# Expansion is monotone (if A's tokens were a subset of B's before, they still
+# are after), so this can only ADD matches, never remove one that worked.
+_COMPOUND_FORMS: dict[str, tuple[str, ...]] = {
+    "frontend": ("front", "end"),
+    "backend": ("back", "end"),
+    "fullstack": ("full", "stack"),
+    "devops": ("dev", "ops"),
+    "qa": ("quality", "assurance"),
+    "ml": ("machine", "learning"),
+    "ai": ("artificial", "intelligence"),
+    "sre": ("site", "reliability", "engineer"),
+    "tpm": ("technical", "program", "manager"),
+}
+
+# Interchangeable words for the same role. "Backend Developer" and "Software
+# Engineering Intern" are ordinary JD titles that a strict token match misses
+# against `backend-engineer` / `software-engineer`.
+_SYNONYM_GROUPS: tuple[frozenset[str], ...] = (
+    frozenset({"engineer", "engineering", "developer", "dev"}),
+)
+
+
+def _expand_role_tokens(tokens: set[str]) -> set[str]:
+    """Add equivalent spellings so title and slug meet in the middle."""
+    expanded = set(tokens)
+    for joined, parts in _COMPOUND_FORMS.items():
+        if joined in tokens:
+            expanded.update(parts)
+        elif all(part in tokens for part in parts):
+            expanded.add(joined)
+    for group in _SYNONYM_GROUPS:
+        if expanded & group:
+            expanded |= group
+    return expanded
+
+
 def _role_tokens(text: str) -> set[str]:
-    """Lowercased alphanumeric tokens of a role string or slug.
+    """Lowercased alphanumeric tokens of a role string or slug, plus variants.
 
     ``"Senior Backend Engineer"`` and ``"backend-engineer"`` both tokenize into
-    comparable sets, so pack slugs can match live JD titles.
+    comparable sets, so pack slugs can match live JD titles. Real titles also
+    spell the same role differently — "Front End", "ML", "Developer" — so the
+    raw tokens are expanded with the equivalent forms above before comparison.
     """
     tokens: set[str] = set()
     current: list[str] = []
@@ -169,7 +212,7 @@ def _role_tokens(text: str) -> set[str]:
             current = []
     if current:
         tokens.add("".join(current))
-    return tokens
+    return _expand_role_tokens(tokens)
 
 
 def effective_confidence(

--- a/apps/agent/tests/test_skilllib.py
+++ b/apps/agent/tests/test_skilllib.py
@@ -135,6 +135,72 @@ def test_find_relevant_matches_jd_titles_and_generic_fallback(tmp_path: Path) ->
     assert hits[0].frontmatter.id == "stripe-backend-engineer-senior"
 
 
+def test_find_relevant_matches_alternate_title_spellings(tmp_path: Path) -> None:
+    """Real JD titles spell roles differently than pack slugs do.
+
+    Strict token matching missed ordinary titles: "Front End Engineer" against a
+    `frontend-engineer` pack (front + end vs frontend), "Backend Developer"
+    (developer vs engineer), and "Software Engineering Intern" (engineering vs
+    engineer). Each miss is silent — the planner just gets no pack — so these
+    are pinned rather than left to be rediscovered.
+    """
+    frontend = _sample_skill().model_copy(deep=True)
+    frontend.frontmatter.id = "generic-frontend-engineer-mid"
+    frontend.frontmatter.company = "generic"
+    frontend.frontmatter.role = "frontend-engineer"
+    frontend.frontmatter.level = "mid"
+    save_skill(frontend, tmp_path / "generic-frontend-engineer-mid.md")
+
+    for title in ("Front End Engineer", "Frontend Developer", "Front-End Dev"):
+        hits = find_relevant(tmp_path, company="Acme", role=title)
+        assert [h.frontmatter.id for h in hits] == ["generic-frontend-engineer-mid"], title
+
+    ml = _sample_skill().model_copy(deep=True)
+    ml.frontmatter.id = "generic-machine-learning-engineer-senior"
+    ml.frontmatter.company = "generic"
+    ml.frontmatter.role = "machine-learning-engineer"
+    save_skill(ml, tmp_path / "generic-machine-learning-engineer-senior.md")
+
+    # "ML Engineer" is at least as common a title as the spelled-out form.
+    hits = find_relevant(tmp_path, company="Acme", role="Senior ML Engineer")
+    assert [h.frontmatter.id for h in hits] == ["generic-machine-learning-engineer-senior"]
+
+
+def test_role_token_expansion_does_not_match_unrelated_roles(tmp_path: Path) -> None:
+    """Expansion must add spellings of the same job, not blur different jobs.
+
+    The risk of loosening a matcher is a backend pack turning up for a designer.
+    A pack whose slug tokens are genuinely absent from the title still loses.
+    """
+    backend = _sample_skill().model_copy(deep=True)
+    backend.frontmatter.id = "generic-backend-engineer-senior"
+    backend.frontmatter.company = "generic"
+    save_skill(backend, tmp_path / "generic-backend-engineer-senior.md")
+
+    for title in ("Product Designer", "Sales Manager", "Data Scientist", "Frontend Engineer"):
+        assert find_relevant(tmp_path, company="Acme", role=title) == [], title
+
+
+def test_role_token_expansion_is_monotone() -> None:
+    """Expansion may only ADD matches — never break one that already worked.
+
+    Both the pack slug and the JD title run through the same expansion, so a
+    subset relation that held on raw tokens must still hold afterwards. If that
+    stops being true, packs silently stop being retrieved.
+    """
+    from deepinterview_agent.skilllib.store import _role_tokens
+
+    pairs = [
+        ("backend-engineer", "Senior Backend Engineer"),
+        ("software-engineer", "Software Engineer"),
+        ("data-engineer", "Staff Data Engineer"),
+        ("engineering-manager", "Engineering Manager, Platform"),
+        ("site-reliability-engineer", "Site Reliability Engineer"),
+    ]
+    for slug, title in pairs:
+        assert _role_tokens(slug) <= _role_tokens(title), (slug, title)
+
+
 def test_find_relevant_ranks_status_then_decayed_confidence(tmp_path: Path) -> None:
     """`promoted` beats `draft` even at lower confidence; staleness decays rank."""
     draft = _sample_skill().model_copy(deep=True)


### PR DESCRIPTION
Found while verifying slugs for the pack library (#72) — by testing retrieval against realistic JD titles rather than assuming it worked.

## The bug
Role matching compares token sets: a pack matches when its slug's tokens are a subset of the JD title's. Tokens split on non-alphanumerics, so these ordinary titles matched **nothing**:

| JD title | Pack it should find | Why it missed |
|---|---|---|
| `Front End Engineer` | `frontend-engineer` | `front` + `end` ≠ `frontend` |
| `Backend Developer` | `backend-engineer` | `developer` ≠ `engineer` |
| `Software Engineering Intern` | `software-engineer` | `engineering` ≠ `engineer` |
| `Senior ML Engineer` | `machine-learning-engineer` | `ml` ≠ `machine` + `learning` |

The failure is **silent** — no pack is retrieved, the planner falls back to CV and JD alone, and the interview is quietly less tailored. Nothing surfaces it.

## The fix
`_role_tokens` expands raw tokens with equivalent spellings before comparison: compound forms (`frontend` ↔ `front`+`end`, `ml` ↔ `machine`+`learning`, plus `sre`, `qa`, `devops`, `tpm`, …) and one synonym group (`engineer` / `engineering` / `developer` / `dev`).

Both sides of the comparison already run through `_role_tokens`, so every entry works in **either direction** — a `front-end-engineer` pack would be found by "Frontend Engineer" too.

## Why this can't break existing matches
Expansion is **monotone**: if a pack's tokens were a subset of a title's before, they still are after, because both sides get the same rules. It can only add matches. That property is pinned by a test rather than left as an argument in a commit message.

## Verification
- Alternate spellings now match: `Front End Engineer`, `Frontend Developer`, `Front-End Dev`, `Senior ML Engineer`.
- Unrelated titles still match nothing — `Product Designer`, `Sales Manager`, `Data Scientist` and `Frontend Engineer` all correctly fail to retrieve a backend pack. Loosening a matcher risks blur; that is the test guarding it.
- Monotonicity pinned across five slug/title pairs.
- `pytest` 219 pass · `ruff` + `prettier` clean.

Independent of #72 — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)