### PR TITLE
fix(web): stop the two infinite spinners in #67

### DIFF
--- a/apps/web/app/report/[id]/page.tsx
+++ b/apps/web/app/report/[id]/page.tsx
@@ -34,9 +34,16 @@ export const dynamic = "force-dynamic";
  * - `empty`   interview produced no answers (status `no_answers`, or a legacy
  *             `complete` row with a blank card) → honest empty state, NOT zeros.
  * - `scoring` interview done but scoring hasn't produced a card yet → poll.
+ * - `preparing` the prep pipeline is still building the plan — the interview
+ *             hasn't happened yet, so "scoring" would be a lie → poll.
+ * - `waiting` prep finished but no interview ever ran (status `ready`, zero
+ *             answers). NOT scoring, and polling can never change it: only the
+ *             voice worker writes a terminal status, so a session whose worker
+ *             never joined would spin forever. See issue #67.
  * - `error`   session errored (scoring failed — retriable) → honest notice.
  */
-type ReportState = "ready" | "sample" | "empty" | "scoring" | "error";
+type ReportState =
+  "ready" | "sample" | "empty" | "scoring" | "preparing" | "waiting" | "error";
 
 interface Loaded {
   state: ReportState;
@@ -125,7 +132,21 @@ async function load(id: string): Promise<Loaded> {
     if (view.status === "complete") {
       return { ...base, state: "error", scorecard: SAMPLE_SCORECARD };
     }
-    // Interview not scored yet — poll until a terminal state arrives.
+    // Prep still running: the interview hasn't happened, so don't claim to be
+    // scoring it. Genuinely transient — poll.
+    if (view.status === "prep") {
+      return { ...base, state: "preparing", scorecard: SAMPLE_SCORECARD };
+    }
+    // Prepped, but nothing was ever recorded. Only the voice worker writes a
+    // terminal status (`complete` / `no_answers`), so if it never joined the
+    // room this session stays `ready` forever — polling it was the infinite
+    // "Scoring your interview…" spinner in #67. Answer the user's real question
+    // instead: the interview hasn't run.
+    if (answers === 0) {
+      return { ...base, state: "waiting", scorecard: SAMPLE_SCORECARD };
+    }
+    // Answers exist but no card yet — scoring really is in flight. Poll, but
+    // the poller gives up and says so rather than spinning forever.
     return { ...base, state: "scoring", scorecard: SAMPLE_SCORECARD };
   } catch {
     return sample;
@@ -196,11 +217,13 @@ export default async function ReportPage({
   // sign-in. (Hosted/multi-tenant deployments add auth as a separate layer.)
   const loaded = await load(id);
 
-  // Still scoring: show a calm waiting state and auto-refresh until terminal.
-  if (loaded.state === "scoring") {
+  // Still scoring, or still prepping: auto-refresh until terminal. The poller
+  // stops after a bounded wait and says so — an indefinite spinner tells the
+  // user nothing and hides a stuck pipeline (#67).
+  if (loaded.state === "scoring" || loaded.state === "preparing") {
+    const preparing = loaded.state === "preparing";
     return (
       <StatusShell>
-        <ScoringPoll />
         <Card className="max-w-md text-center">
           <CardContent className="flex flex-col items-center gap-3 py-10">
             <span
@@ -208,12 +231,69 @@ export default async function ReportPage({
               aria-hidden
             />
             <h1 className="font-serif text-2xl text-ink">
-              Scoring your interview…
+              {preparing
+                ? "Preparing your interview…"
+                : "Scoring your interview…"}
             </h1>
             <p className="max-w-sm text-sm leading-relaxed text-muted">
-              Hang tight — we’re analyzing your answers. This page updates
-              automatically the moment your report is ready.
+              {preparing
+                ? "Reading your CV and the job description to build your question plan. This page updates automatically."
+                : "Hang tight — we’re analyzing your answers. This page updates automatically the moment your report is ready."}
             </p>
+            <ScoringPoll
+              stalledMessage={
+                preparing
+                  ? "Prep is taking longer than expected. It runs on your configured LLM provider — check the agent logs for a failing prep stage, then reload."
+                  : "Scoring is taking longer than expected. Check the agent API logs for a failing scoring stage, then reload this page."
+              }
+            />
+          </CardContent>
+        </Card>
+      </StatusShell>
+    );
+  }
+
+  // Prepped, but no interview ever ran. This is the state a session sits in
+  // when the voice worker never joined the room — the worker is a separate
+  // process (`docker compose --profile live up`), and nothing else writes a
+  // terminal status. Say that, instead of pretending to score nothing (#67).
+  if (loaded.state === "waiting") {
+    return (
+      <StatusShell>
+        <Card className="max-w-md text-center">
+          <CardContent className="flex flex-col items-center gap-4 py-10">
+            <h1 className="font-serif text-2xl text-ink">
+              This interview hasn’t run yet
+            </h1>
+            <p className="max-w-sm text-sm leading-relaxed text-muted">
+              {loaded.role && loaded.company ? (
+                <>
+                  Your {loaded.role} interview at {loaded.company} is prepped
+                  and ready, but no answers were recorded — so there’s nothing
+                  to score.{" "}
+                </>
+              ) : (
+                <>
+                  This interview is prepped and ready, but no answers were
+                  recorded — so there’s nothing to score.{" "}
+                </>
+              )}
+              Join the interview to start it. If you just finished one and are
+              seeing this, the voice worker didn’t save a result — it runs as a
+              separate process, so check that it’s running and that your LiveKit
+              keys are set.
+            </p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link
+                href={`/interview/${encodeURIComponent(id)}`}
+                className={buttonClasses()}
+              >
+                Join interview
+              </Link>
+              <Link href="/setup" className={buttonClasses({ variant: "out" })}>
+                Start over
+              </Link>
+            </div>
           </CardContent>
         </Card>
       </StatusShell>

--- a/apps/web/components/interview/live-room.tsx
+++ b/apps/web/components/interview/live-room.tsx
@@ -37,6 +37,7 @@ import {
   useConnectionState,
   useLocalParticipant,
   useTranscriptions,
+  useVoiceAssistant,
 } from "@livekit/components-react";
 import {
   ConnectionState,
@@ -206,6 +207,38 @@ function Scaffold({
 /* LIVE session — descendant of <LiveKitRoom>; owns all LiveKit hooks. */
 /* ------------------------------------------------------------------ */
 
+/**
+ * True when the room has been connected for `afterMs` and the agent has NEVER
+ * joined it.
+ *
+ * The voice worker is a separate process (`docker compose --profile live up`),
+ * so a correctly-configured browser can join a room that no agent is listening
+ * on. LiveKit reports that as a perfectly healthy connection — the room is up,
+ * the mic works, nothing errors — and the stage sits on "Connecting your
+ * interviewer…" indefinitely with nothing to act on (issue #67).
+ *
+ * "Never" is deliberate: tracked with a ref so a mid-interview blip, or the
+ * agent leaving at the end, can't retroactively raise a "didn't join" notice.
+ */
+function useAgentNeverJoined(
+  connected: boolean,
+  agentPresent: boolean,
+  afterMs = 20_000,
+) {
+  const everJoined = React.useRef(false);
+  const [waitedTooLong, setWaitedTooLong] = React.useState(false);
+
+  if (agentPresent) everJoined.current = true;
+
+  React.useEffect(() => {
+    if (!connected || everJoined.current) return;
+    const t = setTimeout(() => setWaitedTooLong(true), afterMs);
+    return () => clearTimeout(t);
+  }, [connected, afterMs]);
+
+  return waitedTooLong && !everJoined.current;
+}
+
 function LiveSession({
   persona,
   sessionId,
@@ -227,6 +260,13 @@ function LiveSession({
 
   const { localParticipant, isMicrophoneEnabled } = useLocalParticipant();
   const transcriptions = useTranscriptions();
+  // `disconnected` is what useVoiceAssistant reports while no agent participant
+  // is in the room at all — the case the notice below explains.
+  const { state: agentState } = useVoiceAssistant();
+  const agentNeverJoined = useAgentNeverJoined(
+    connected,
+    agentState !== "disconnected",
+  );
 
   const [ending, setEnding] = React.useState(false);
 
@@ -346,6 +386,11 @@ function LiveSession({
           <ErrorNotice
             title="Microphone unavailable"
             message={`${micError} Until then, you can type your answers below.`}
+          />
+        ) : agentNeverJoined ? (
+          <ErrorNotice
+            title="Your interviewer hasn’t joined"
+            message="You’re connected to the room, but the voice worker never arrived. It runs as a separate process — start it with `docker compose --profile live up` and check LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET plus your STT/TTS/LLM keys in the root .env. You can type your answers below in the meantime."
           />
         ) : reconnecting ? (
           <div

--- a/apps/web/components/report/scoring-poll.tsx
+++ b/apps/web/components/report/scoring-poll.tsx
@@ -1,20 +1,49 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 /**
  * Re-runs the server component (which re-fetches the session view) on an
- * interval while post-interview scoring is still in flight, so the report
- * flips to the real result the moment it's ready — without the user refreshing.
- * Renders nothing; unmounts (and stops polling) once `load()` returns a terminal
- * state and the page no longer renders this.
+ * interval while the session is still in flight, so the report flips to the
+ * real result the moment it's ready — without the user refreshing.
+ *
+ * Polling is BOUNDED. A session only leaves its non-terminal state because
+ * something else writes to it (the voice worker at shutdown, or the scoring
+ * stage), and when that something is broken or was never running, an unbounded
+ * poll spins forever behind a spinner that claims progress — the "Grading your
+ * interview" hang in issue #67. After `stopAfterMs` the interval is cleared and
+ * `stalledMessage` is shown, so a stuck pipeline looks stuck.
  */
-export function ScoringPoll({ intervalMs = 2500 }: { intervalMs?: number }) {
+export function ScoringPoll({
+  intervalMs = 2500,
+  stopAfterMs = 120_000,
+  stalledMessage,
+}: {
+  intervalMs?: number;
+  stopAfterMs?: number;
+  stalledMessage?: string;
+}) {
   const router = useRouter();
+  const [stalled, setStalled] = useState(false);
+
   useEffect(() => {
-    const t = setInterval(() => router.refresh(), intervalMs);
-    return () => clearInterval(t);
-  }, [router, intervalMs]);
-  return null;
+    if (stalled) return;
+    const poll = setInterval(() => router.refresh(), intervalMs);
+    const deadline = setTimeout(() => setStalled(true), stopAfterMs);
+    return () => {
+      clearInterval(poll);
+      clearTimeout(deadline);
+    };
+  }, [router, intervalMs, stopAfterMs, stalled]);
+
+  if (!stalled || !stalledMessage) return null;
+  return (
+    <p
+      role="status"
+      className="mt-2 max-w-sm text-sm leading-relaxed text-muted"
+    >
+      {stalledMessage}
+    </p>
+  );
 }


### PR DESCRIPTION
Fixes the reproducible half of #67.

## What I actually found
I reproduced both hangs against a live stack. **Neither the voice loop nor the scoring pipeline is broken** — scoring a real session took **21s** and completed with a valid scorecard. What's broken is that the UI can't tell *"in progress"* from *"never going to happen"*, and renders the same spinner for both, forever.

### Leg 1 — "Scoring your interview…" that never ends
`load()` treated **every** non-terminal status as `scoring`. But only the voice worker writes a terminal status (`complete` / `no_answers`), at shutdown — and the worker is a **separate, opt-in process** (`docker compose --profile live up`). So a session whose worker never joined sits at `ready` with zero answers, and the report claims to be "analyzing your answers" that don't exist, polling every 2.5s **forever**, because nothing can ever change it.

Reproduction, before the fix — prep a session, never run an interview, open the report:

```
status = ready | answers = 0 | scorecard = False
→ "Scoring your interview… we're analyzing your answers"   (polls forever)
```

Now split by what the session actually is:

| Session | Before | After |
|---|---|---|
| status `prep` | "Scoring your interview…" | "Preparing your interview…" |
| `ready`, zero answers | "Scoring your interview…" **forever** | "This interview hasn't run yet" + Join link + why |
| answers, no card | "Scoring your interview…" | unchanged |
| `complete` + card | full report | unchanged |

Polling is also **bounded** (120s), after which it says the stage looks stuck and where to look, instead of spinning behind a message that claims progress.

### Leg 2 — "Connecting your interviewer…" that never ends
A browser can join a room that no agent is listening on. LiveKit reports this as a perfectly healthy connection — room up, mic working, nothing errors — so `useVoiceAssistant()` stays `disconnected` and the stage waits forever on a message with nothing to act on. The only notices the room had were mic failure and reconnecting; neither fires here.

After 20s connected with the agent having never joined, the room now says so and names what to check (the worker process, `LIVEKIT_*`). Tracked with a ref so a mid-interview blip — or the agent leaving at the end — can't retroactively raise a "didn't join" notice.

## Verification
`apps/web` has no test runner, so this was verified against a **live stack** (agent API + web + real providers), driving each state through the actual HTTP path:

- `prep` → "Preparing your interview…"
- `ready` + 0 answers → "This interview hasn't run yet" *(the exact session that reproduced the bug)*
- `ready` + 1 answer, no card → "Scoring your interview…" (regression — must not become the new state)
- `POST /api/score` → `complete` → full report renders with real competency scores

`pnpm lint` · `pnpm typecheck` · `pnpm build` all clean.

## What this does NOT fix
The reporter also hit this on the hosted site. This PR makes that failure **legible** rather than silent, but if the hosted deployment's worker isn't running, the fix is in the deployment, not here. Worth checking separately before closing #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)