### PR TITLE
fixed: no attribute 'identity' and added unmuted handler

### DIFF
--- a/apps/agent/src/deepinterview_agent/worker.py
+++ b/apps/agent/src/deepinterview_agent/worker.py
@@ -67,8 +67,12 @@ def wire_audio_path_logging(ctx: JobContext, session) -> None:
         log.info("audio-path: track SUBSCRIBED kind=%s from %s", _kind(pub), p.identity)
 
     @ctx.room.on("track_muted")
-    def _on_muted(pub, p) -> None:
+    def _on_muted(p, pub) -> None:
         log.info("audio-path: track MUTED kind=%s by %s", _kind(pub), p.identity)
+
+    @ctx.room.on("track_unmuted")
+    def _on_unmuted(p, pub) -> None:
+        log.info("audio-path: track UNMUTED kind=%s by %s", _kind(pub), p.identity)
 
     for p in ctx.room.remote_participants.values():
         pubs = {sid: _kind(pub) for sid, pub in p.track_publications.items()}


### PR DESCRIPTION
<!--
Thanks for contributing to DeepInterview! Keep PRs small — one work package
(or one focused change) per PR. See CONTRIBUTING.md for the full workflow.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences. -->
Clicking the mute button triggers an error:

```
2026-08-26 23:44:07,061 ERROR livekit: failed to emit event track_muted
Traceback (most recent call last):
  File "/app/.venv/lib/python3.11/site-packages/livekit/rtc/event_emitter.py", line 58, in emit
    callback(*callback_args)
  File "/app/src/deepinterview_agent/worker.py", line 71, in _on_muted
    log.info("audio-path: track MUTED kind=%s by %s", _kind(pub), p.identity)
                                                                  ^^^^^^^^^^
AttributeError: 'RemoteTrackPublication' object has no attribute 'identity'
2026-08-26 23:44:07,061 ERROR livekit: failed to emit event track_muted
Traceback (most recent call last):
  File "/app/.venv/lib/python3.11/site-packages/livekit/rtc/event_emitter.py", line 58, in emit
    callback(*callback_args)
  File "/app/src/deepinterview_agent/worker.py", line 71, in _on_muted
    log.info("audio-path: track MUTED kind=%s by %s", _kind(pub), p.identity)
                                                                  ^^^^^^^^^^
AttributeError: 'RemoteTrackPublication' object has no attribute 'identity'
Traceback (most recent call last):
  File "/app/.venv/lib/python3.11/site-packages/livekit/rtc/event_emitter.py", line 58, in emit
    callback(*callback_args)
  File "/app/src/deepinterview_agent/worker.py", line 71, in _on_muted
    log.info("audio-path: track MUTED kind=%s by %s", _kind(pub), p.identity)
                                                                  ^^^^^^^^^^
AttributeError: 'RemoteTrackPublication' object has no attribute 'identity'
{"message": "failed to emit event track_muted\nTraceback (most recent call last):\n  File \"/app/.venv/lib/python3.11/site-packages/livekit/rtc/event_emitter.py\", line 58, in emit\n    callback(*callback_args)\n  File \"/app/src/deepinterview_agent/worker.py\", line 71, in _on_muted\n    log.info(\"audio-path: track MUTED kind=%s by %s\", _kind(pub), p.identity)\n                                                                  ^^^^^^^^^^\nAttributeError: 'RemoteTrackPublication' object has no attribute 'identity'", "level": "ERROR", "name": "livekit", "exc_info": "Traceback (most recent call last):\n  File \"/app/.venv/lib/python3.11/site-packages/livekit/rtc/event_emitter.py\", line 58, in emit\n    callback(*callback_args)\n  File \"/app/src/deepinterview_agent/worker.py\", line 71, in _on_muted\n    log.info(\"audio-path: track MUTED kind=%s by %s\", _kind(pub), p.identity)\n                                                                  ^^^^^^^^^^\nAttributeError: 'RemoteTrackPublication' object has no attribute 'identity'", "pid": 70, "job_id": "AJ_gKQVATKowH28", "room": "sess_0c4c2db6fb2642e1b428b3bc822c18f3", "timestamp": "2026-08-26T23:44:07.061748+00:00"}
```

The 'track_muted' handler signature is wrong. Participant (p) and TrackPublication (pub) parameters are inverted. This, according to the documentation:

```
"track_muted": Called when a track is muted.

Arguments: participant (Participant), publication (TrackPublication)

"track_unmuted": Called when a track is unmuted.

Arguments: participant (Participant), publication (TrackPublication)
```

Additionally I added a quick unmuted handler for completeness.

## Work package

<!-- Which WP does this touch? See AI-Interviewer-Build-Handoff.md §16. -->

- [ ] WP-0 — Monorepo + shared contracts + CLI scaffold
- [ ] WP-1 — Web: auth + setup/onboarding
- [ ] WP-2 — Web: live interview screen
- [ ] WP-3 — Web: report / feedback screen
- [ ] WP-4 — Web: Prep Coach UI
- [ ] WP-5 — Agent: live voice interviewer
- [ ] WP-6 — Agent: prep pipeline
- [ ] WP-7 — Agent: scoring pipeline
- [ ] WP-8 — Knowledge service (LightRAG)
- [ ] WP-9 — Avatar system
- [ ] WP-10 — Skill library + distiller
- [ ] WP-11 — Payments + plan gating
- [ ] WP-12 — DevOps / deploy / observability
- [ ] WP-13 — OSS launch assets
- [ ] Other / cross-cutting (docs, chore, CI)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
      (`feat:`, `fix:`, `docs:`, `chore:`, …).
- [ ] `pnpm build` is green.
- [ ] `pnpm typecheck` is green.
- [ ] `pnpm lint` is green.
- [ ] `pnpm test` is green.
- [ ] `uv --directory apps/agent run pytest` is green (if Python touched).
- [ ] The **offline / mock-first** path still works with **no API keys set**
      (no provider key required to run the prep → live → post loop locally).
- [ ] No secrets committed (`.env*`, real keys/tokens, recordings).
- [ ] Docs updated where behavior or contracts changed (README, `docs/`,
      `packages/shared` contract docs, or the handoff spec).
- [ ] Shared contracts stay in sync: TS ↔ Pydantic parity holds
      (`packages/shared` + the agent parity test) if I changed any contract.

## Notes for reviewers

<!-- Anything tricky, follow-ups, or out-of-scope items intentionally left. -->
